### PR TITLE
Move Utility and Use References

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3079,6 +3079,694 @@
 		</xs:sequence>
 		<xs:attribute name="ID" type="xs:ID"/>
 	</xs:complexType>
+	<xs:complexType name="UtilityType">
+		<xs:sequence>
+			<xs:element name="RateSchedule" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Rate structure characteristics.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="RateStructureName" type="xs:string" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The name or title of the rate structure.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="TypeOfRateStructure" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Basic type of rate structure used by the utility.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<xs:element name="FlatRate" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>A consumer will pay one flat rate no matter what the usage level is</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="RatePeriodName" type="xs:string" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The name or title of rate period.This is intended to capture the seasonal changes in rates.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableStartDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableEndDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="DemandWindow" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The time period of measurement through which the demand is established. (min)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:integer">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="DemandRatchetPercentage" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Certain rate schedules incorporate demand ratchet percentage to ensure minimum billing demands based on historical peak demands. Billing demand in these cases is based comparing the month's demand and maximum of previous 11 month's demand times the demand ratchet percentage. (0-1) (%)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="EnergyCostRate" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Energy rate to buy a unit of energy consumption. ($/unit)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="EnergyRateAdjustment" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Energy rate adjustment for any fees, riders, fuel adjustments ($/unit)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="ElectricDemandRate" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The rate to buy electric demand from the utility. ($/kW)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="DemandRateAdjustment" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The rate for any fees, riders, fuel adjustments ($/kW)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="EnergySellRate" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Energy rate to sell a unit of electricity back to the utility from customer site generation through PV, wind etc. ($/kWh)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="TimeOfUseRate" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>TOU rates vary by time of day and time of year</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="RatePeriodName" type="xs:string" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The name or title of rate period.This is intended to capture the seasonal changes in rates.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableStartDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableEndDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="TimeOfUsePeriod" minOccurs="0" maxOccurs="unbounded">
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="TOUNumberForRateStructure" type="xs:int" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The number associated with the TOU period.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="ApplicableStartTimeForEnergyRate" type="xs:time" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="ApplicableEndTimeForEnergyRate" type="xs:time" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="ApplicableStartTimeForDemandRate" type="xs:time" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="ApplicableEndTimeForDemandRate" type="xs:time" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="EnergyCostRate" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Energy rate to buy a unit of energy consumption. ($/unit)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="ElectricDemandRate" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The rate to buy electric demand from the utility. ($/kW)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="EnergyRateAdjustment" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Energy rate adjustment for any fees, riders, fuel adjustments ($/unit)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="DemandRateAdjustment" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The rate for any fees, riders, fuel adjustments ($/kW)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="DemandWindow" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The time period of measurement through which the demand is established. (min)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:integer">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="DemandRatchetPercentage" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Certain rate schedules incorporate demand ratchet percentage to ensure minimum billing demands based on historical peak demands. Billing demand in these cases is based comparing the month's demand and maximum of previous 11 month's demand times the demand ratchet percentage. (0-1) (%)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="EnergySellRate" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Energy rate to sell a unit of electricity back to the utility from customer site generation through PV, wind etc. ($/kWh)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="TieredRate" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Tiered rates increase the per-unit price of a utility as usage increases</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="RatePeriodName" type="xs:string" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The name or title of rate period.This is intended to capture the seasonal changes in rates.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="RateTier" minOccurs="0" maxOccurs="unbounded">
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="ConsumptionEnergyTierDesignation" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:integer">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="MaxkWhUsage" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The maximum amount of kWh used at which a kWh rate is applied (kWh)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="MaxkWUsage" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The maximum amount of kW used at which a kW rate is applied (kW)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="EnergyCostRate" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Energy rate to buy a unit of energy consumption. ($/unit)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="ElectricDemandRate" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The rate to buy electric demand from the utility. ($/kW)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="EnergyRateAdjustment" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Energy rate adjustment for any fees, riders, fuel adjustments ($/unit)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="DemandRateAdjustment" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The rate for any fees, riders, fuel adjustments ($/kW)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="DemandWindow" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>The time period of measurement through which the demand is established. (min)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:integer">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																		<xs:element name="DemandRatchetPercentage" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Certain rate schedules incorporate demand ratchet percentage to ensure minimum billing demands based on historical peak demands. Billing demand in these cases is based comparing the month's demand and maximum of previous 11 month's demand times the demand ratchet percentage. (0-1) (%)</xs:documentation>
+																			</xs:annotation>
+																			<xs:complexType>
+																				<xs:simpleContent>
+																					<xs:extension base="xs:decimal">
+																						<xs:attribute ref="auc:Source"/>
+																					</xs:extension>
+																				</xs:simpleContent>
+																			</xs:complexType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="EnergySellRate" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Energy rate to sell a unit of electricity back to the utility from customer site generation through PV, wind etc. ($/kWh)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:decimal">
+																			<xs:attribute ref="auc:Source"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="TierDirection" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Whether the rates increase or decrease as energy use increases.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:enumeration value="Increasing"/>
+															<xs:enumeration value="Decreasing"/>
+															<xs:enumeration value="Other"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="RealTimePricing" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>(RTP) - pricing rates generally apply to usage on an hourly basis.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="VariablePeakPricing" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>(VPP) - a hybrid of time-of-use and real-time pricing where the different periods for pricing are defined in advance (e.g., on-peak=6 hours for summer weekday afternoon; off-peak = all other hours in the summer months), but the price established for the on-peak period varies by utility and market conditions.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CriticalPeakPricing" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>(CPP) - when utilities observe or anticipate high wholesale market prices or power system emergency conditions, they may call critical events during a specified time period (e.g., 3 p.m.—6 p.m. on a hot summer weekday), the price for electricity during these time periods is substantially raised. Two variants of this type of rate design exist: one where the time and duration of the price increase are predetermined when events are called and another where the time and duration of the price increase may vary based on the electric grid’s need to have loads reduced</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CriticalPeakRebates" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>(CPR) - when utilities observe or anticipate high wholesale market prices or power system emergency conditions, they may call critical events during pre-specified time periods (e.g., 3 p.m.—6 p.m. summer weekday afternoons), the price for electricity during these time periods remains the same but the customer is refunded at a single, predetermined value for any reduction in consumption relative to what the utility deemed the customer was expected to consume.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Other" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Other type of rate structure, or combination of other types.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Unknown" minOccurs="0"/>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="RateStructureSector" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sector to which the rate structure is applicable.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:enumeration value="Residential"/>
+									<xs:enumeration value="Commercial"/>
+									<xs:enumeration value="Industrial"/>
+									<xs:enumeration value="Other"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="ReferenceForRateStructure" type="xs:string" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Reference or hyper link for the rate schedule, tariff book</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RateStructureEffectiveDate" type="xs:date" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The first date the rate schedule becomes applicable. (CCYY-MM-DD)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RateStructureEndDate" type="xs:date" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The date at which the rate schedule is no longer applicable. (CCYY-MM-DD)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ReactivePowerCharge" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The additional charge for low power factor. ($/kVAR)</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="xs:decimal">
+										<xs:attribute ref="auc:Source"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="MinimumPowerFactorWithoutPenalty" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Minimum power factor that needs to maintained without any penalties. (0-1) (%)</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="xs:decimal">
+										<xs:attribute ref="auc:Source"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="FixedMonthlyCharge" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The fixed charge or fee billed monthly regardless of consumption. ($/month)</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="xs:decimal">
+										<xs:attribute ref="auc:Source"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="NetMetering" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Present if a billing mechanism is employed by utilities to credit onsite energy generation for this rate structure.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="AverageMarginalSellRate" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Annual average rate to sell a unit of electricity back to the utility from customer site electricity generation through PV, wind etc. ($/kWh)</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:simpleContent>
+												<xs:extension base="xs:decimal">
+													<xs:attribute ref="auc:Source"/>
+												</xs:extension>
+											</xs:simpleContent>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="AverageMarginalCostRate" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>The annual average cost of providing an additional unit of energy or water. Units should be consistent with Resource Units. ($/unit)</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="xs:decimal">
+										<xs:attribute ref="auc:Source"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="ID" type="xs:ID"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="MeteringConfiguration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The structure of how the various meters are arranged</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="Direct metering"/>
+						<xs:enumeration value="Master meter without sub metering"/>
+						<xs:enumeration value="Master meter with sub metering"/>
+						<xs:enumeration value="Other"/>
+						<xs:enumeration value="Unknown"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="TypeOfResourceMeter" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Meters can be divided into several categories based on their capabilities</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="Revenue grade meter"/>
+						<xs:enumeration value="Advanced resource meter"/>
+						<xs:enumeration value="Analog"/>
+						<xs:enumeration value="Interval"/>
+						<xs:enumeration value="Net"/>
+						<xs:enumeration value="Smart meter"/>
+						<xs:enumeration value="PDU input meter"/>
+						<xs:enumeration value="IT equipment input meter"/>
+						<xs:enumeration value="Supply UPS output meter"/>
+						<xs:enumeration value="PDU output meter"/>
+						<xs:enumeration value="Other"/>
+						<xs:enumeration value="Unknown"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="FuelInterruptibility" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This refers to the practice of supplementing fuel (electricity, natural gas, fuel oil.) by other means when there are interruptions in supply from the utility.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="Interruptible"/>
+						<xs:enumeration value="Firm"/>
+						<xs:enumeration value="Other"/>
+						<xs:enumeration value="Unknown"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UtilityName" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Name of utility company billing a Resource.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PowerPlant" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Name of an individual power plant to which the property is directly connected</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UtilityMeterNumber" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Unique identification number for the meter</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UtilityAccountNumber" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Unique account number designated by the utility</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UtilityBillpayer" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Organization that is responsible for paying the bills associated with this meter.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ElectricDistributionUtility" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The company responsible for maintaining the utility lines and the electric distribution to the property. Note that the EDU is not the just "the utility company." In some states the energy markets are deregulated. This means that a property may contract with Company A to provide the power supply (energy from the power plant), while Company B will continue to provide the electric distribution (Company B is the EDU).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SourceSiteRatio" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Ratio of energy consumed at a central power plant to that delivered to a customer.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:decimal">
+							<xs:attribute ref="auc:Source"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:complexType name="ResourceUseType">
 		<xs:sequence>
 			<xs:element ref="auc:EnergyResource" minOccurs="0"/>
@@ -3158,696 +3846,7 @@
 					</xs:simpleContent>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="Utility" minOccurs="0" maxOccurs="unbounded">
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="RateSchedule" minOccurs="0" maxOccurs="unbounded">
-							<xs:annotation>
-								<xs:documentation>Rate structure characteristics.</xs:documentation>
-							</xs:annotation>
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="RateStructureName" type="xs:string" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>The name or title of the rate structure.</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element name="TypeOfRateStructure" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>Basic type of rate structure used by the utility.</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:choice>
-												<xs:element name="FlatRate" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>A consumer will pay one flat rate no matter what the usage level is</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
-																<xs:complexType>
-																	<xs:sequence>
-																		<xs:element name="RatePeriodName" type="xs:string" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The name or title of rate period.This is intended to capture the seasonal changes in rates.</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableStartDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableEndDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="DemandWindow" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The time period of measurement through which the demand is established. (min)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:integer">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="DemandRatchetPercentage" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>Certain rate schedules incorporate demand ratchet percentage to ensure minimum billing demands based on historical peak demands. Billing demand in these cases is based comparing the month's demand and maximum of previous 11 month's demand times the demand ratchet percentage. (0-1) (%)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="EnergyCostRate" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>Energy rate to buy a unit of energy consumption. ($/unit)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="EnergyRateAdjustment" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>Energy rate adjustment for any fees, riders, fuel adjustments ($/unit)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="ElectricDemandRate" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The rate to buy electric demand from the utility. ($/kW)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="DemandRateAdjustment" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The rate for any fees, riders, fuel adjustments ($/kW)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="EnergySellRate" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>Energy rate to sell a unit of electricity back to the utility from customer site generation through PV, wind etc. ($/kWh)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																	</xs:sequence>
-																</xs:complexType>
-															</xs:element>
-														</xs:sequence>
-													</xs:complexType>
-												</xs:element>
-												<xs:element name="TimeOfUseRate" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>TOU rates vary by time of day and time of year</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
-																<xs:complexType>
-																	<xs:sequence>
-																		<xs:element name="RatePeriodName" type="xs:string" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The name or title of rate period.This is intended to capture the seasonal changes in rates.</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableStartDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableEndDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="TimeOfUsePeriod" minOccurs="0" maxOccurs="unbounded">
-																			<xs:complexType>
-																				<xs:sequence>
-																					<xs:element name="TOUNumberForRateStructure" type="xs:int" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The number associated with the TOU period.</xs:documentation>
-																						</xs:annotation>
-																					</xs:element>
-																					<xs:element name="ApplicableStartTimeForEnergyRate" type="xs:time" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-																						</xs:annotation>
-																					</xs:element>
-																					<xs:element name="ApplicableEndTimeForEnergyRate" type="xs:time" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-																						</xs:annotation>
-																					</xs:element>
-																					<xs:element name="ApplicableStartTimeForDemandRate" type="xs:time" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-																						</xs:annotation>
-																					</xs:element>
-																					<xs:element name="ApplicableEndTimeForDemandRate" type="xs:time" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-																						</xs:annotation>
-																					</xs:element>
-																					<xs:element name="EnergyCostRate" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>Energy rate to buy a unit of energy consumption. ($/unit)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="ElectricDemandRate" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The rate to buy electric demand from the utility. ($/kW)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="EnergyRateAdjustment" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>Energy rate adjustment for any fees, riders, fuel adjustments ($/unit)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="DemandRateAdjustment" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The rate for any fees, riders, fuel adjustments ($/kW)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="DemandWindow" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The time period of measurement through which the demand is established. (min)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:integer">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="DemandRatchetPercentage" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>Certain rate schedules incorporate demand ratchet percentage to ensure minimum billing demands based on historical peak demands. Billing demand in these cases is based comparing the month's demand and maximum of previous 11 month's demand times the demand ratchet percentage. (0-1) (%)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																				</xs:sequence>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="EnergySellRate" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>Energy rate to sell a unit of electricity back to the utility from customer site generation through PV, wind etc. ($/kWh)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																	</xs:sequence>
-																</xs:complexType>
-															</xs:element>
-														</xs:sequence>
-													</xs:complexType>
-												</xs:element>
-												<xs:element name="TieredRate" minOccurs="0" maxOccurs="unbounded">
-													<xs:annotation>
-														<xs:documentation>Tiered rates increase the per-unit price of a utility as usage increases</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
-																<xs:complexType>
-																	<xs:sequence>
-																		<xs:element name="RatePeriodName" type="xs:string" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The name or title of rate period.This is intended to capture the seasonal changes in rates.</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
-																			</xs:annotation>
-																		</xs:element>
-																		<xs:element name="RateTier" minOccurs="0" maxOccurs="unbounded">
-																			<xs:complexType>
-																				<xs:sequence>
-																					<xs:element name="ConsumptionEnergyTierDesignation" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:integer">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="MaxkWhUsage" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The maximum amount of kWh used at which a kWh rate is applied (kWh)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="MaxkWUsage" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The maximum amount of kW used at which a kW rate is applied (kW)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="EnergyCostRate" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>Energy rate to buy a unit of energy consumption. ($/unit)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="ElectricDemandRate" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The rate to buy electric demand from the utility. ($/kW)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="EnergyRateAdjustment" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>Energy rate adjustment for any fees, riders, fuel adjustments ($/unit)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="DemandRateAdjustment" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The rate for any fees, riders, fuel adjustments ($/kW)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="DemandWindow" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>The time period of measurement through which the demand is established. (min)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:integer">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																					<xs:element name="DemandRatchetPercentage" minOccurs="0">
-																						<xs:annotation>
-																							<xs:documentation>Certain rate schedules incorporate demand ratchet percentage to ensure minimum billing demands based on historical peak demands. Billing demand in these cases is based comparing the month's demand and maximum of previous 11 month's demand times the demand ratchet percentage. (0-1) (%)</xs:documentation>
-																						</xs:annotation>
-																						<xs:complexType>
-																							<xs:simpleContent>
-																								<xs:extension base="xs:decimal">
-																									<xs:attribute ref="auc:Source"/>
-																								</xs:extension>
-																							</xs:simpleContent>
-																						</xs:complexType>
-																					</xs:element>
-																				</xs:sequence>
-																			</xs:complexType>
-																		</xs:element>
-																		<xs:element name="EnergySellRate" minOccurs="0">
-																			<xs:annotation>
-																				<xs:documentation>Energy rate to sell a unit of electricity back to the utility from customer site generation through PV, wind etc. ($/kWh)</xs:documentation>
-																			</xs:annotation>
-																			<xs:complexType>
-																				<xs:simpleContent>
-																					<xs:extension base="xs:decimal">
-																						<xs:attribute ref="auc:Source"/>
-																					</xs:extension>
-																				</xs:simpleContent>
-																			</xs:complexType>
-																		</xs:element>
-																	</xs:sequence>
-																</xs:complexType>
-															</xs:element>
-															<xs:element name="TierDirection" minOccurs="0">
-																<xs:annotation>
-																	<xs:documentation>Whether the rates increase or decrease as energy use increases.</xs:documentation>
-																</xs:annotation>
-																<xs:simpleType>
-																	<xs:restriction base="xs:string">
-																		<xs:enumeration value="Increasing"/>
-																		<xs:enumeration value="Decreasing"/>
-																		<xs:enumeration value="Other"/>
-																	</xs:restriction>
-																</xs:simpleType>
-															</xs:element>
-														</xs:sequence>
-													</xs:complexType>
-												</xs:element>
-												<xs:element name="RealTimePricing" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>(RTP) - pricing rates generally apply to usage on an hourly basis.</xs:documentation>
-													</xs:annotation>
-												</xs:element>
-												<xs:element name="VariablePeakPricing" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>(VPP) - a hybrid of time-of-use and real-time pricing where the different periods for pricing are defined in advance (e.g., on-peak=6 hours for summer weekday afternoon; off-peak = all other hours in the summer months), but the price established for the on-peak period varies by utility and market conditions.</xs:documentation>
-													</xs:annotation>
-												</xs:element>
-												<xs:element name="CriticalPeakPricing" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>(CPP) - when utilities observe or anticipate high wholesale market prices or power system emergency conditions, they may call critical events during a specified time period (e.g., 3 p.m.—6 p.m. on a hot summer weekday), the price for electricity during these time periods is substantially raised. Two variants of this type of rate design exist: one where the time and duration of the price increase are predetermined when events are called and another where the time and duration of the price increase may vary based on the electric grid’s need to have loads reduced</xs:documentation>
-													</xs:annotation>
-												</xs:element>
-												<xs:element name="CriticalPeakRebates" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>(CPR) - when utilities observe or anticipate high wholesale market prices or power system emergency conditions, they may call critical events during pre-specified time periods (e.g., 3 p.m.—6 p.m. summer weekday afternoons), the price for electricity during these time periods remains the same but the customer is refunded at a single, predetermined value for any reduction in consumption relative to what the utility deemed the customer was expected to consume.</xs:documentation>
-													</xs:annotation>
-												</xs:element>
-												<xs:element name="Other" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>Other type of rate structure, or combination of other types.</xs:documentation>
-													</xs:annotation>
-												</xs:element>
-												<xs:element name="Unknown" minOccurs="0"/>
-											</xs:choice>
-										</xs:complexType>
-									</xs:element>
-									<xs:element name="RateStructureSector" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>Sector to which the rate structure is applicable.</xs:documentation>
-										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:enumeration value="Residential"/>
-												<xs:enumeration value="Commercial"/>
-												<xs:enumeration value="Industrial"/>
-												<xs:enumeration value="Other"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:element>
-									<xs:element name="ReferenceForRateStructure" type="xs:string" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>Reference or hyper link for the rate schedule, tariff book</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element name="RateStructureEffectiveDate" type="xs:date" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>The first date the rate schedule becomes applicable. (CCYY-MM-DD)</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element name="RateStructureEndDate" type="xs:date" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>The date at which the rate schedule is no longer applicable. (CCYY-MM-DD)</xs:documentation>
-										</xs:annotation>
-									</xs:element>
-									<xs:element name="ReactivePowerCharge" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>The additional charge for low power factor. ($/kVAR)</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:simpleContent>
-												<xs:extension base="xs:decimal">
-													<xs:attribute ref="auc:Source"/>
-												</xs:extension>
-											</xs:simpleContent>
-										</xs:complexType>
-									</xs:element>
-									<xs:element name="MinimumPowerFactorWithoutPenalty" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>Minimum power factor that needs to maintained without any penalties. (0-1) (%)</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:simpleContent>
-												<xs:extension base="xs:decimal">
-													<xs:attribute ref="auc:Source"/>
-												</xs:extension>
-											</xs:simpleContent>
-										</xs:complexType>
-									</xs:element>
-									<xs:element name="FixedMonthlyCharge" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>The fixed charge or fee billed monthly regardless of consumption. ($/month)</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:simpleContent>
-												<xs:extension base="xs:decimal">
-													<xs:attribute ref="auc:Source"/>
-												</xs:extension>
-											</xs:simpleContent>
-										</xs:complexType>
-									</xs:element>
-									<xs:element name="NetMetering" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>Present if a billing mechanism is employed by utilities to credit onsite energy generation for this rate structure.</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element name="AverageMarginalSellRate" minOccurs="0">
-													<xs:annotation>
-														<xs:documentation>Annual average rate to sell a unit of electricity back to the utility from customer site electricity generation through PV, wind etc. ($/kWh)</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:simpleContent>
-															<xs:extension base="xs:decimal">
-																<xs:attribute ref="auc:Source"/>
-															</xs:extension>
-														</xs:simpleContent>
-													</xs:complexType>
-												</xs:element>
-											</xs:sequence>
-										</xs:complexType>
-									</xs:element>
-									<xs:element name="AverageMarginalCostRate" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>The annual average cost of providing an additional unit of energy or water. Units should be consistent with Resource Units. ($/unit)</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:simpleContent>
-												<xs:extension base="xs:decimal">
-													<xs:attribute ref="auc:Source"/>
-												</xs:extension>
-											</xs:simpleContent>
-										</xs:complexType>
-									</xs:element>
-								</xs:sequence>
-								<xs:attribute name="ID" type="xs:ID"/>
-							</xs:complexType>
-						</xs:element>
-						<xs:element name="MeteringConfiguration" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>The structure of how the various meters are arranged</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:restriction base="xs:string">
-									<xs:enumeration value="Direct metering"/>
-									<xs:enumeration value="Master meter without sub metering"/>
-									<xs:enumeration value="Master meter with sub metering"/>
-									<xs:enumeration value="Other"/>
-									<xs:enumeration value="Unknown"/>
-								</xs:restriction>
-							</xs:simpleType>
-						</xs:element>
-						<xs:element name="TypeOfResourceMeter" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Meters can be divided into several categories based on their capabilities</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:restriction base="xs:string">
-									<xs:enumeration value="Revenue grade meter"/>
-									<xs:enumeration value="Advanced resource meter"/>
-									<xs:enumeration value="Analog"/>
-									<xs:enumeration value="Interval"/>
-									<xs:enumeration value="Net"/>
-									<xs:enumeration value="Smart meter"/>
-									<xs:enumeration value="PDU input meter"/>
-									<xs:enumeration value="IT equipment input meter"/>
-									<xs:enumeration value="Supply UPS output meter"/>
-									<xs:enumeration value="PDU output meter"/>
-									<xs:enumeration value="Other"/>
-									<xs:enumeration value="Unknown"/>
-								</xs:restriction>
-							</xs:simpleType>
-						</xs:element>
-						<xs:element name="FuelInterruptibility" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>This refers to the practice of supplementing fuel (electricity, natural gas, fuel oil.) by other means when there are interruptions in supply from the utility.</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:restriction base="xs:string">
-									<xs:enumeration value="Interruptible"/>
-									<xs:enumeration value="Firm"/>
-									<xs:enumeration value="Other"/>
-									<xs:enumeration value="Unknown"/>
-								</xs:restriction>
-							</xs:simpleType>
-						</xs:element>
-						<xs:element name="UtilityName" type="xs:string" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Name of utility company billing a Resource.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="PowerPlant" type="xs:string" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Name of an individual power plant to which the property is directly connected</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="UtilityMeterNumber" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-							<xs:annotation>
-								<xs:documentation>Unique identification number for the meter</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="UtilityAccountNumber" type="xs:string" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Unique account number designated by the utility</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="UtilityBillpayer" type="xs:string" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Organization that is responsible for paying the bills associated with this meter.</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="ElectricDistributionUtility" type="xs:string" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>The company responsible for maintaining the utility lines and the electric distribution to the property. Note that the EDU is not the just "the utility company." In some states the energy markets are deregulated. This means that a property may contract with Company A to provide the power supply (energy from the power plant), while Company B will continue to provide the electric distribution (Company B is the EDU).</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="SourceSiteRatio" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Ratio of energy consumed at a central power plant to that delivered to a customer.</xs:documentation>
-							</xs:annotation>
-							<xs:complexType>
-								<xs:simpleContent>
-									<xs:extension base="xs:decimal">
-										<xs:attribute ref="auc:Source"/>
-									</xs:extension>
-								</xs:simpleContent>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
+			<xs:element name="Utility" type="auc:UtilityType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="Emissions" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:sequence>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -529,6 +529,17 @@
 												</xs:restriction>
 											</xs:simpleType>
 										</xs:element>
+										<xs:element name ="Utilities" minOccurs="0">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="Utility" type="auc:UtilityType" minOccurs="0" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Utility associated with a scenario or scenarios.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
 										<xs:element name="AuditorContactID" minOccurs="0">
 											<xs:annotation>
 												<xs:documentation>Contact ID of auditor responsible for the audit report.</xs:documentation>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3777,6 +3777,7 @@
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
+		<xs:attribute name="ID" type="xs:ID"/>
 	</xs:complexType>
 	<xs:complexType name="ResourceUseType">
 		<xs:sequence>
@@ -3858,6 +3859,14 @@
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Utility" type="auc:UtilityType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="UtilityID" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>ID of utility associated with this resource use.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
+				</xs:complexType>
+			</xs:element>
 			<xs:element name="Emissions" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:sequence>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3858,7 +3858,6 @@
 					</xs:simpleContent>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="Utility" type="auc:UtilityType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="UtilityID" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>ID of utility associated with this resource use.</xs:documentation>

--- a/examples/PrimarySchoolCRB1.xml
+++ b/examples/PrimarySchoolCRB1.xml
@@ -9614,23 +9614,7 @@
 							<AnnualFuelUseNativeUnits>1235643</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>4219</AnnualFuelUseConsistentUnits>
 							<FuelUseIntensity>5.86</FuelUseIntensity>
-							<Utility>
-								<RateSchedule ID="ElectricUtility2">
-									<TypeOfRateStructure>
-										<FlatRate>
-											<RatePeriod>
-												<EnergyCostRate>0.084</EnergyCostRate>
-												<EnergyRateAdjustment>0.0067</EnergyRateAdjustment>
-												<ElectricDemandRate>5.75</ElectricDemandRate>
-												<DemandRateAdjustment>0.46</DemandRateAdjustment>
-											</RatePeriod>
-										</FlatRate>
-									</TypeOfRateStructure>
-									<RateStructureSector>Commercial</RateStructureSector>
-									<AverageMarginalCostRate>0.091</AverageMarginalCostRate>
-								</RateSchedule>
-								<SourceSiteRatio>3</SourceSiteRatio>
-							</Utility>
+							<UtilityID IDref="ElectricUtility1"/>
 						</ResourceUse>
 						<ResourceUse ID="PackageNatGas1">
 							<EnergyResource>Natural gas</EnergyResource>
@@ -9642,21 +9626,7 @@
 							<AnnualFuelUseNativeUnits>77866</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>7787</AnnualFuelUseConsistentUnits>
 							<FuelUseIntensity>0.369</FuelUseIntensity>
-							<Utility>
-								<RateSchedule ID="GasUtility2">
-									<TypeOfRateStructure>
-										<FlatRate>
-											<RatePeriod>
-												<EnergyCostRate>0.865</EnergyCostRate>
-												<EnergyRateAdjustment>0.069</EnergyRateAdjustment>
-											</RatePeriod>
-										</FlatRate>
-									</TypeOfRateStructure>
-									<RateStructureSector>Commercial</RateStructureSector>
-									<AverageMarginalCostRate>0.934</AverageMarginalCostRate>
-								</RateSchedule>
-								<SourceSiteRatio>1</SourceSiteRatio>
-							</Utility>
+							<UtilityID IDref="GasUtility1"/>
 						</ResourceUse>
 					</ResourceUses>
 					<TimeSeriesData>

--- a/examples/PrimarySchoolCRB1.xml
+++ b/examples/PrimarySchoolCRB1.xml
@@ -9475,23 +9475,7 @@
 							<AnnualFuelUseNativeUnits>2000000</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>6829</AnnualFuelUseConsistentUnits>
 							<FuelUseIntensity>9.49</FuelUseIntensity>
-							<Utility>
-								<RateSchedule ID="ElectricUtility1">
-									<TypeOfRateStructure>
-										<FlatRate>
-											<RatePeriod>
-												<EnergyCostRate>0.084</EnergyCostRate>
-												<EnergyRateAdjustment>0.0067</EnergyRateAdjustment>
-												<ElectricDemandRate>5.75</ElectricDemandRate>
-												<DemandRateAdjustment>0.46</DemandRateAdjustment>
-											</RatePeriod>
-										</FlatRate>
-									</TypeOfRateStructure>
-									<RateStructureSector>Commercial</RateStructureSector>
-									<AverageMarginalCostRate>0.091</AverageMarginalCostRate>
-								</RateSchedule>
-								<SourceSiteRatio>3</SourceSiteRatio>
-							</Utility>
+							<UtilityID IDref="ElectricUtility1"/>
 						</ResourceUse>
 						<ResourceUse ID="BaseNatGas1">
 							<EnergyResource>Natural gas</EnergyResource>
@@ -9503,21 +9487,7 @@
 							<AnnualFuelUseNativeUnits>120000</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>12000</AnnualFuelUseConsistentUnits>
 							<FuelUseIntensity>0.569</FuelUseIntensity>
-							<Utility>
-								<RateSchedule ID="GasUtility1">
-									<TypeOfRateStructure>
-										<FlatRate>
-											<RatePeriod>
-												<EnergyCostRate>0.865</EnergyCostRate>
-												<EnergyRateAdjustment>0.069</EnergyRateAdjustment>
-											</RatePeriod>
-										</FlatRate>
-									</TypeOfRateStructure>
-									<RateStructureSector>Commercial</RateStructureSector>
-									<AverageMarginalCostRate>0.934</AverageMarginalCostRate>
-								</RateSchedule>
-								<SourceSiteRatio>1</SourceSiteRatio>
-							</Utility>
+							<UtilityID IDref="GasUtility1"/>
 						</ResourceUse>
 					</ResourceUses>
 					<TimeSeriesData>
@@ -9750,6 +9720,40 @@
 			<ElectricityPriceEscalationRate>0.05</ElectricityPriceEscalationRate>
 			<WaterPriceEscalationRate>0.05</WaterPriceEscalationRate>
 			<InflationRate>0.03</InflationRate>
+			<Utilities>
+				<Utility ID="ElectricUtility1">
+					<RateSchedule>
+						<TypeOfRateStructure>
+							<FlatRate>
+								<RatePeriod>
+									<EnergyCostRate>0.084</EnergyCostRate>
+									<EnergyRateAdjustment>0.0067</EnergyRateAdjustment>
+									<ElectricDemandRate>5.75</ElectricDemandRate>
+									<DemandRateAdjustment>0.46</DemandRateAdjustment>
+								</RatePeriod>
+							</FlatRate>
+						</TypeOfRateStructure>
+						<RateStructureSector>Commercial</RateStructureSector>
+						<AverageMarginalCostRate>0.091</AverageMarginalCostRate>
+					</RateSchedule>
+					<SourceSiteRatio>3</SourceSiteRatio>
+				</Utility>
+				<Utility ID="GasUtility1">
+					<RateSchedule>
+						<TypeOfRateStructure>
+							<FlatRate>
+								<RatePeriod>
+									<EnergyCostRate>0.865</EnergyCostRate>
+									<EnergyRateAdjustment>0.069</EnergyRateAdjustment>
+								</RatePeriod>
+							</FlatRate>
+						</TypeOfRateStructure>
+						<RateStructureSector>Commercial</RateStructureSector>
+						<AverageMarginalCostRate>0.934</AverageMarginalCostRate>
+					</RateSchedule>
+					<SourceSiteRatio>1</SourceSiteRatio>
+				</Utility>
+			</Utilities>
 		</Report>
 	</Audit>
 </Audits>

--- a/examples/ashrae211.xml
+++ b/examples/ashrae211.xml
@@ -1242,13 +1242,7 @@
 							<PercentEndUse>1</PercentEndUse>
 							<AnnualFuelUseNativeUnits>25740</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>2574</AnnualFuelUseConsistentUnits>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9921</UtilityAccountNumber>
-							</Utility>
+							<UtilityID IDref="Utility1"/>
 						</ResourceUse>
 						<ResourceUse ID="Resource3">
 							<EnergyResource>Fuel oil</EnergyResource>
@@ -1259,27 +1253,9 @@
 							<PercentEndUse>1</PercentEndUse>
 							<AnnualFuelUseNativeUnits>148500</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>1782</AnnualFuelUseConsistentUnits>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter without sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9998</UtilityAccountNumber>
-							</Utility>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9224</UtilityAccountNumber>
-							</Utility>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9994</UtilityAccountNumber>
-							</Utility>
+							<UtilityID IDref="Utility2"/>
+							<UtilityID IDref="Utility3"/>
+							<UtilityID IDref="Utility4"/>
 						</ResourceUse>
 						<ResourceUse ID="Resource4">
 							<EnergyResource>Fuel oil no 5 and no 6</EnergyResource>
@@ -1290,27 +1266,9 @@
 							<PercentEndUse>1</PercentEndUse>
 							<AnnualFuelUseNativeUnits>450</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>4.95</AnnualFuelUseConsistentUnits>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter without sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9998</UtilityAccountNumber>
-							</Utility>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9224</UtilityAccountNumber>
-							</Utility>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9994</UtilityAccountNumber>
-							</Utility>
+							<UtilityID IDref="Utility5"/>
+							<UtilityID IDref="Utility6"/>
+							<UtilityID IDref="Utility7"/>
 						</ResourceUse>
 						<ResourceUse ID="Resource5">
 							<EnergyResource>Fuel oil</EnergyResource>
@@ -1321,27 +1279,9 @@
 							<PercentEndUse>1</PercentEndUse>
 							<AnnualFuelUseNativeUnits>390</AnnualFuelUseNativeUnits>
 							<AnnualFuelUseConsistentUnits>31.2</AnnualFuelUseConsistentUnits>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter without sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9998</UtilityAccountNumber>
-							</Utility>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9224</UtilityAccountNumber>
-							</Utility>
-							<Utility>
-								<RateSchedule>
-									<RateStructureName>WSE 999-999</RateStructureName>
-								</RateSchedule>
-								<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
-								<UtilityAccountNumber>999-9994</UtilityAccountNumber>
-							</Utility>
+							<UtilityID IDref="Utility8"/>
+							<UtilityID IDref="Utility9"/>
+							<UtilityID IDref="Utility10"/>
 						</ResourceUse>
 					</ResourceUses>
 					<TimeSeriesData>
@@ -2559,6 +2499,78 @@
 				</Scenario>
 			</Scenarios>
 			<AuditDate>2015-02-05</AuditDate>
+			<Utilities>
+				<Utility ID="Utility1">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9921</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility2">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter without sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9998</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility3">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9224</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility4">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9994</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility5">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter without sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9998</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility6">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9224</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility7">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9994</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility8">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter without sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9998</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility9">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9224</UtilityAccountNumber>
+				</Utility>
+				<Utility ID="Utility10">
+					<RateSchedule>
+						<RateStructureName>WSE 999-999</RateStructureName>
+					</RateSchedule>
+					<MeteringConfiguration>Master meter with sub metering</MeteringConfiguration>
+					<UtilityAccountNumber>999-9994</UtilityAccountNumber>
+				</Utility>
+			</Utilities>
 			<AuditorContactID IDref="Auditor1"/>
 		</Report>
 		<Contacts>


### PR DESCRIPTION
This PR moves the utility element out of the resource use element and up to a place where multiple resource use elements can refer to it. This was an early PNNL request that we held off on making because it is a breaking change. Any files using the previous approach will no longer work.