### PR TITLE
Fix path to BuildingSync XML schema file

### DIFF
--- a/examples/Centers for Medicare and Medicaid (CMS) Woodlawn Campus
+++ b/examples/Centers for Medicare and Medicaid (CMS) Woodlawn Campus
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 file:///C:/Users/Robert/Documents/GitHub/BuildingSync/schema/BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 ../BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<Audit>
 		<Sites>
 			<Site>

--- a/examples/NIST Gaithersburg Campus
+++ b/examples/NIST Gaithersburg Campus
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 file:///C:/Users/Robert/Documents/GitHub/BuildingSync/schema/BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 ../BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<Audit>
 		<Sites>
 			<Site>

--- a/examples/Norfolk Federal Building
+++ b/examples/Norfolk Federal Building
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 file:///C:/Users/Robert/Documents/GitHub/BuildingSync/schema/BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 ../BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<Audit>
 		<Sites>
 			<Site>

--- a/examples/Richmond Federal Building
+++ b/examples/Richmond Federal Building
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 file:///C:/Users/Robert/Documents/GitHub/BuildingSync/schema/BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Audits xsi:schemaLocation="http://nrel.gov/schemas/bedes-auc/2014 ../BuildingSync.xsd" xmlns="http://nrel.gov/schemas/bedes-auc/2014" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<Audit>
 		<Sites>
 			<Site>


### PR DESCRIPTION
The path to the `BuildingSync.xsd` file was absolute for some example files. Resolved by replacing absolute path with relative path.