### PR TITLE
Define types for (untyped) XML elements

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -15134,6 +15134,10 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 			<xs:enumeration value="None"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:element name="NoCooling" type="xs:string" fixed=""/>
-	<xs:element name="NoHeating" type="xs:string" fixed=""/>
+	<xs:element name="NoCooling">
+		<xs:complexType/>
+	</xs:element>
+	<xs:element name="NoHeating">
+		<xs:complexType/>
+	</xs:element>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3595,7 +3595,7 @@
 														<xs:documentation>Other type of rate structure, or combination of other types.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element name="Unknown" minOccurs="0"/>
+												<xs:element ref="auc:Unknown" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -5635,7 +5635,7 @@
 												</xs:element>
 												<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 												<xs:element ref="auc:NoHeating" minOccurs="0"/>
-												<xs:element name="Unknown" minOccurs="0"/>
+												<xs:element ref="auc:Unknown" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -5842,7 +5842,7 @@
 												</xs:element>
 												<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 												<xs:element ref="auc:NoCooling" minOccurs="0"/>
-												<xs:element name="Unknown" minOccurs="0"/>
+												<xs:element ref="auc:Unknown" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -7158,7 +7158,7 @@
 				</xs:element>
 				<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 				<xs:element ref="auc:NoHeating" minOccurs="0"/>
-				<xs:element name="Unknown" minOccurs="0"/>
+				<xs:element ref="auc:Unknown" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="HeatingPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
 		</xs:sequence>
@@ -7433,7 +7433,7 @@
 				</xs:element>
 				<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 				<xs:element ref="auc:NoCooling" minOccurs="0"/>
-				<xs:element name="Unknown" minOccurs="0"/>
+				<xs:element ref="auc:Unknown" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="CoolingPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
 		</xs:sequence>
@@ -7783,7 +7783,7 @@
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="Other" minOccurs="0"/>
-				<xs:element name="Unknown" minOccurs="0"/>
+				<xs:element ref="auc:Unknown" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="CondenserPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
 		</xs:sequence>
@@ -8065,7 +8065,7 @@
 							</xs:complexType>
 						</xs:element>
 						<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-						<xs:element name="Unknown" minOccurs="0"/>
+						<xs:element ref="auc:Unknown" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -8304,7 +8304,7 @@
 						<xs:element ref="auc:Photoluminescent" minOccurs="0"/>
 						<xs:element ref="auc:SelfLuminous" minOccurs="0"/>
 						<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-						<xs:element name="Unknown" minOccurs="0"/>
+						<xs:element ref="auc:Unknown" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -8698,7 +8698,7 @@
 																			</xs:complexType>
 																		</xs:element>
 																		<xs:element name="Other" minOccurs="0"/>
-																		<xs:element name="Unknown" minOccurs="0"/>
+																		<xs:element ref="auc:Unknown" minOccurs="0"/>
 																	</xs:choice>
 																</xs:complexType>
 															</xs:element>
@@ -8869,7 +8869,7 @@
 																			</xs:complexType>
 																		</xs:element>
 																		<xs:element name="Other" minOccurs="0"/>
-																		<xs:element name="Unknown" minOccurs="0"/>
+																		<xs:element ref="auc:Unknown" minOccurs="0"/>
 																	</xs:choice>
 																</xs:complexType>
 															</xs:element>
@@ -8877,7 +8877,7 @@
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Other" minOccurs="0"/>
-												<xs:element name="Unknown" minOccurs="0"/>
+												<xs:element ref="auc:Unknown" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -8986,7 +8986,7 @@
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Other" minOccurs="0"/>
-												<xs:element name="Unknown" minOccurs="0"/>
+												<xs:element ref="auc:Unknown" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -8997,7 +8997,7 @@
 							<xs:complexType/>
 						</xs:element>
 						<xs:element name="Other" minOccurs="0"/>
-						<xs:element name="Unknown" minOccurs="0"/>
+						<xs:element ref="auc:Unknown" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -9848,7 +9848,7 @@
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="Other" minOccurs="0"/>
-						<xs:element name="Unknown" minOccurs="0"/>
+						<xs:element ref="auc:Unknown" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -12015,7 +12015,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Other" minOccurs="0"/>
-												<xs:element name="Unknown" minOccurs="0"/>
+												<xs:element ref="auc:Unknown" minOccurs="0"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -12149,7 +12149,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="Other" minOccurs="0"/>
-						<xs:element name="Unknown" minOccurs="0"/>
+						<xs:element ref="auc:Unknown" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -15169,6 +15169,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="SelfLuminous">
+		<xs:complexType/>
+	</xs:element>
+	<xs:element name="Unknown">
 		<xs:complexType/>
 	</xs:element>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -15150,5 +15150,5 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="SelfLuminousType"/>
-	<xs:complexType name="Unknown"/>
+	<xs:complexType name="UnknownType"/>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -8356,7 +8356,7 @@
 						</xs:element>
 						<xs:element ref="auc:Neon" minOccurs="0"/>
 						<xs:element ref="auc:Plasma" minOccurs="0"/>
-						<xs:element name="Photoluminescent" minOccurs="0"/>
+						<xs:element ref="auc:Photoluminescent" minOccurs="0"/>
 						<xs:element name="SelfLuminous" minOccurs="0"/>
 						<xs:element name="OtherCombination" minOccurs="0"/>
 						<xs:element name="Unknown" minOccurs="0"/>
@@ -15141,6 +15141,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		<xs:complexType/>
 	</xs:element>
 	<xs:element name="NoHeating">
+		<xs:complexType/>
+	</xs:element>
+	<xs:element name="Photoluminescent">
 		<xs:complexType/>
 	</xs:element>
 	<xs:element name="Plasma">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -13028,7 +13028,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="Estimated" minOccurs="0"/>
+			<xs:element ref="auc:Estimated" minOccurs="0"/>
 			<xs:element name="Other" minOccurs="0"/>
 		</xs:choice>
 	</xs:complexType>
@@ -15104,6 +15104,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="ElectricResistance">
+		<xs:complexType/>
+	</xs:element>
+	<xs:element name="Estimated">
 		<xs:complexType/>
 	</xs:element>
 	<xs:element name="Neon">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -8689,7 +8689,7 @@
 																</xs:annotation>
 																<xs:complexType>
 																	<xs:choice>
-																		<xs:element name="ElectricResistance" minOccurs="0"/>
+																		<xs:element ref="auc:ElectricResistance" minOccurs="0"/>
 																		<xs:element name="Combustion" minOccurs="0">
 																			<xs:complexType>
 																				<xs:sequence>
@@ -8977,7 +8977,7 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:choice>
-												<xs:element name="ElectricResistance" minOccurs="0"/>
+												<xs:element ref="auc:ElectricResistance" minOccurs="0"/>
 												<xs:element name="Combustion" minOccurs="0">
 													<xs:complexType>
 														<xs:sequence>
@@ -15102,6 +15102,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 				</xs:element>
 			</xs:sequence>
 		</xs:complexType>
+	</xs:element>
+	<xs:element name="ElectricResistance">
+		<xs:complexType/>
 	</xs:element>
 	<xs:element name="Neon">
 		<xs:complexType/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -8993,7 +8993,9 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="HeatExchanger" minOccurs="0"/>
+						<xs:element name="HeatExchanger" minOccurs="0">
+							<xs:complexType/>
+						</xs:element>
 						<xs:element name="Other" minOccurs="0"/>
 						<xs:element name="Unknown" minOccurs="0"/>
 					</xs:choice>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3629,21 +3629,25 @@
 													<xs:annotation>
 														<xs:documentation>(RTP) - pricing rates generally apply to usage on an hourly basis.</xs:documentation>
 													</xs:annotation>
+													<xs:complexType/>
 												</xs:element>
 												<xs:element name="VariablePeakPricing" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>(VPP) - a hybrid of time-of-use and real-time pricing where the different periods for pricing are defined in advance (e.g., on-peak=6 hours for summer weekday afternoon; off-peak = all other hours in the summer months), but the price established for the on-peak period varies by utility and market conditions.</xs:documentation>
 													</xs:annotation>
+													<xs:complexType/>
 												</xs:element>
 												<xs:element name="CriticalPeakPricing" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>(CPP) - when utilities observe or anticipate high wholesale market prices or power system emergency conditions, they may call critical events during a specified time period (e.g., 3 p.m.—6 p.m. on a hot summer weekday), the price for electricity during these time periods is substantially raised. Two variants of this type of rate design exist: one where the time and duration of the price increase are predetermined when events are called and another where the time and duration of the price increase may vary based on the electric grid’s need to have loads reduced</xs:documentation>
 													</xs:annotation>
+													<xs:complexType/>
 												</xs:element>
 												<xs:element name="CriticalPeakRebates" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>(CPR) - when utilities observe or anticipate high wholesale market prices or power system emergency conditions, they may call critical events during pre-specified time periods (e.g., 3 p.m.—6 p.m. summer weekday afternoons), the price for electricity during these time periods remains the same but the customer is refunded at a single, predetermined value for any reduction in consumption relative to what the utility deemed the customer was expected to consume.</xs:documentation>
 													</xs:annotation>
+													<xs:complexType/>
 												</xs:element>
 												<xs:element name="Other" minOccurs="0">
 													<xs:annotation>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -702,26 +702,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="CBECS" minOccurs="0">
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="ClimateZone" minOccurs="0">
-										<xs:annotation>
-											<xs:documentation>Based on the Climate Zone Type term, this is the climate zone designation.</xs:documentation>
-										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:enumeration value="1"/>
-												<xs:enumeration value="2"/>
-												<xs:enumeration value="3"/>
-												<xs:enumeration value="4"/>
-												<xs:enumeration value="5"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:element>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
+						<xs:element ref="auc:CBECS" minOccurs="0"/>
 						<xs:element name="DOE" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
@@ -978,47 +959,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="PortfolioManager" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>If exists then the data for this facility is included in Portfolio Manager.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="PMBenchmarkDate" type="xs:date" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Date that the building was benchmarked in Portfolio Manager. (CCYY-MM-DD)</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="BuildingProfileStatus" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>The status of the building profile submission process for Portfolio Manager.</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:restriction base="xs:string">
-									<xs:enumeration value="Draft"/>
-									<xs:enumeration value="Received"/>
-									<xs:enumeration value="Under Review"/>
-									<xs:enumeration value="On Hold"/>
-									<xs:enumeration value="Reviewed and Approved"/>
-									<xs:enumeration value="Reviewed and Not Approved"/>
-								</xs:restriction>
-							</xs:simpleType>
-						</xs:element>
-						<xs:element name="FederalSustainabilityChecklistCompletionPercentage" minOccurs="0">
-							<xs:annotation>
-								<xs:documentation>Percentage of the Federal High Performance Sustainability Checklist that has been completed for federal building in Portfolio Manager. (0-100)</xs:documentation>
-							</xs:annotation>
-							<xs:complexType>
-								<xs:simpleContent>
-									<xs:extension base="xs:decimal">
-										<xs:attribute ref="auc:Source"/>
-									</xs:extension>
-								</xs:simpleContent>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
+			<xs:element ref="auc:PortfolioManager" minOccurs="0"/>
 			<xs:element name="NumberOfBusinesses" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Number of separate business tenants within the premises.</xs:documentation>
@@ -2282,8 +2223,8 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:choice>
-												<xs:element name="PortfolioManager" minOccurs="0"/>
-												<xs:element name="CBECS" minOccurs="0"/>
+												<xs:element ref="auc:PortfolioManager" minOccurs="0"/>
+												<xs:element ref="auc:CBECS" minOccurs="0"/>
 												<xs:element name="CodeMinimum" minOccurs="0">
 													<xs:complexType>
 														<xs:sequence>
@@ -15138,6 +15079,26 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 			<xs:enumeration value="None"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:element name="CBECS">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="ClimateZone" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Based on the Climate Zone Type term, this is the climate zone designation.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+							<xs:enumeration value="4"/>
+							<xs:enumeration value="5"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
 	<xs:element name="Neon">
 		<xs:complexType/>
 	</xs:element>
@@ -15155,6 +15116,47 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 	</xs:element>
 	<xs:element name="Plasma">
 		<xs:complexType/>
+	</xs:element>
+	<xs:element name="PortfolioManager">
+		<xs:annotation>
+			<xs:documentation>If exists then the data for this facility is included in Portfolio Manager.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="PMBenchmarkDate" type="xs:date" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Date that the building was benchmarked in Portfolio Manager. (CCYY-MM-DD)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="BuildingProfileStatus" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>The status of the building profile submission process for Portfolio Manager.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Draft"/>
+							<xs:enumeration value="Received"/>
+							<xs:enumeration value="Under Review"/>
+							<xs:enumeration value="On Hold"/>
+							<xs:enumeration value="Reviewed and Approved"/>
+							<xs:enumeration value="Reviewed and Not Approved"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="FederalSustainabilityChecklistCompletionPercentage" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Percentage of the Federal High Performance Sustainability Checklist that has been completed for federal building in Portfolio Manager. (0-100)</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:decimal">
+								<xs:attribute ref="auc:Source"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
 	</xs:element>
 	<xs:element name="SelfLuminous">
 		<xs:complexType/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -5689,7 +5689,7 @@
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="OtherCombination" minOccurs="0"/>
-												<xs:element name="NoHeating" minOccurs="0"/>
+												<xs:element ref="auc:NoHeating" minOccurs="0"/>
 												<xs:element name="Unknown" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
@@ -7212,7 +7212,7 @@
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="OtherCombination" minOccurs="0"/>
-				<xs:element name="NoHeating" minOccurs="0"/>
+				<xs:element ref="auc:NoHeating" minOccurs="0"/>
 				<xs:element name="Unknown" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="HeatingPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
@@ -15135,4 +15135,5 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:element name="NoCooling" type="xs:string" fixed=""/>
+	<xs:element name="NoHeating" type="xs:string" fixed=""/>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -8355,7 +8355,7 @@
 							</xs:complexType>
 						</xs:element>
 						<xs:element ref="auc:Neon" minOccurs="0"/>
-						<xs:element name="Plasma" minOccurs="0"/>
+						<xs:element ref="auc:Plasma" minOccurs="0"/>
 						<xs:element name="Photoluminescent" minOccurs="0"/>
 						<xs:element name="SelfLuminous" minOccurs="0"/>
 						<xs:element name="OtherCombination" minOccurs="0"/>
@@ -15141,6 +15141,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		<xs:complexType/>
 	</xs:element>
 	<xs:element name="NoHeating">
+		<xs:complexType/>
+	</xs:element>
+	<xs:element name="Plasma">
 		<xs:complexType/>
 	</xs:element>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -8357,7 +8357,7 @@
 						<xs:element ref="auc:Neon" minOccurs="0"/>
 						<xs:element ref="auc:Plasma" minOccurs="0"/>
 						<xs:element ref="auc:Photoluminescent" minOccurs="0"/>
-						<xs:element name="SelfLuminous" minOccurs="0"/>
+						<xs:element ref="auc:SelfLuminous" minOccurs="0"/>
 						<xs:element name="OtherCombination" minOccurs="0"/>
 						<xs:element name="Unknown" minOccurs="0"/>
 					</xs:choice>
@@ -15147,6 +15147,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		<xs:complexType/>
 	</xs:element>
 	<xs:element name="Plasma">
+		<xs:complexType/>
+	</xs:element>
+	<xs:element name="SelfLuminous">
 		<xs:complexType/>
 	</xs:element>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -5688,7 +5688,7 @@
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="OtherCombination" minOccurs="0"/>
+												<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 												<xs:element ref="auc:NoHeating" minOccurs="0"/>
 												<xs:element name="Unknown" minOccurs="0"/>
 											</xs:choice>
@@ -5895,7 +5895,7 @@
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="OtherCombination" minOccurs="0"/>
+												<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 												<xs:element ref="auc:NoCooling" minOccurs="0"/>
 												<xs:element name="Unknown" minOccurs="0"/>
 											</xs:choice>
@@ -7211,7 +7211,7 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="OtherCombination" minOccurs="0"/>
+				<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 				<xs:element ref="auc:NoHeating" minOccurs="0"/>
 				<xs:element name="Unknown" minOccurs="0"/>
 			</xs:choice>
@@ -7486,7 +7486,7 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="OtherCombination" minOccurs="0"/>
+				<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 				<xs:element ref="auc:NoCooling" minOccurs="0"/>
 				<xs:element name="Unknown" minOccurs="0"/>
 			</xs:choice>
@@ -8119,7 +8119,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="OtherCombination" minOccurs="0"/>
+						<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 						<xs:element name="Unknown" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
@@ -8358,7 +8358,7 @@
 						<xs:element ref="auc:Plasma" minOccurs="0"/>
 						<xs:element ref="auc:Photoluminescent" minOccurs="0"/>
 						<xs:element ref="auc:SelfLuminous" minOccurs="0"/>
-						<xs:element name="OtherCombination" minOccurs="0"/>
+						<xs:element ref="auc:OtherCombination" minOccurs="0"/>
 						<xs:element name="Unknown" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
@@ -15141,6 +15141,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 		<xs:complexType/>
 	</xs:element>
 	<xs:element name="NoHeating">
+		<xs:complexType/>
+	</xs:element>
+	<xs:element name="OtherCombination">
 		<xs:complexType/>
 	</xs:element>
 	<xs:element name="Photoluminescent">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -2942,7 +2942,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="Other" minOccurs="0"/>
+						<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -3594,7 +3594,7 @@
 													</xs:annotation>
 													<xs:complexType/>
 												</xs:element>
-												<xs:element name="Other" minOccurs="0">
+												<xs:element name="Other" type="auc:OtherType" minOccurs="0">
 													<xs:annotation>
 														<xs:documentation>Other type of rate structure, or combination of other types.</xs:documentation>
 													</xs:annotation>
@@ -6408,7 +6408,7 @@
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="Other" minOccurs="0"/>
+												<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -7786,7 +7786,7 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="Other" minOccurs="0"/>
+				<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 				<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="CondenserPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
@@ -8701,7 +8701,7 @@
 																				</xs:sequence>
 																			</xs:complexType>
 																		</xs:element>
-																		<xs:element name="Other" minOccurs="0"/>
+																		<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 																		<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 																	</xs:choice>
 																</xs:complexType>
@@ -8872,7 +8872,7 @@
 																				</xs:sequence>
 																			</xs:complexType>
 																		</xs:element>
-																		<xs:element name="Other" minOccurs="0"/>
+																		<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 																		<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 																	</xs:choice>
 																</xs:complexType>
@@ -8880,7 +8880,7 @@
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="Other" minOccurs="0"/>
+												<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
@@ -8989,7 +8989,7 @@
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="Other" minOccurs="0"/>
+												<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
@@ -9000,7 +9000,7 @@
 						<xs:element name="HeatExchanger" minOccurs="0">
 							<xs:complexType/>
 						</xs:element>
-						<xs:element name="Other" minOccurs="0"/>
+						<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
@@ -9851,7 +9851,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="Other" minOccurs="0"/>
+						<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
@@ -11623,7 +11623,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="Other" minOccurs="0"/>
+						<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -12018,7 +12018,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element name="Other" minOccurs="0"/>
+												<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:sequence>
 										</xs:complexType>
@@ -12152,7 +12152,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="Other" minOccurs="0"/>
+						<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
@@ -13025,7 +13025,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 									<xs:element name="DirectMeasurement" minOccurs="0">
 										<xs:complexType/>
 									</xs:element>
-									<xs:element name="Other" minOccurs="0"/>
+									<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 								</xs:choice>
 							</xs:complexType>
 						</xs:element>
@@ -13033,7 +13033,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Estimated" type="auc:EstimatedType" minOccurs="0"/>
-			<xs:element name="Other" minOccurs="0"/>
+			<xs:element name="Other" type="auc:OtherType" minOccurs="0"/>
 		</xs:choice>
 	</xs:complexType>
 	<xs:element name="Quantity">
@@ -15111,6 +15111,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 	<xs:complexType name="NoCoolingType"/>
 	<xs:complexType name="NoHeatingType"/>
 	<xs:complexType name="OtherCombinationType"/>
+	<xs:complexType name="OtherType"/>
 	<xs:complexType name="PhotoluminescentType"/>
 	<xs:complexType name="PlasmaType"/>
 	<xs:complexType name="PortfolioManagerType">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -702,7 +702,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element ref="auc:CBECS" minOccurs="0"/>
+						<xs:element name="CBECS" type="auc:CBECSType" minOccurs="0"/>
 						<xs:element name="DOE" minOccurs="0">
 							<xs:complexType>
 								<xs:sequence>
@@ -959,7 +959,11 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element ref="auc:PortfolioManager" minOccurs="0"/>
+			<xs:element name="PortfolioManager" type="auc:PortfolioManagerType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If exists then the data for this facility is included in Portfolio Manager.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="NumberOfBusinesses" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Number of separate business tenants within the premises.</xs:documentation>
@@ -2223,8 +2227,8 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:choice>
-												<xs:element ref="auc:PortfolioManager" minOccurs="0"/>
-												<xs:element ref="auc:CBECS" minOccurs="0"/>
+												<xs:element name="PortfolioManager" type="auc:PortfolioManagerType" minOccurs="0"/>
+												<xs:element name="CBECS" type="auc:CBECSType" minOccurs="0"/>
 												<xs:element name="CodeMinimum" minOccurs="0">
 													<xs:complexType>
 														<xs:sequence>
@@ -3595,7 +3599,7 @@
 														<xs:documentation>Other type of rate structure, or combination of other types.</xs:documentation>
 													</xs:annotation>
 												</xs:element>
-												<xs:element ref="auc:Unknown" minOccurs="0"/>
+												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -5633,9 +5637,9 @@
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-												<xs:element ref="auc:NoHeating" minOccurs="0"/>
-												<xs:element ref="auc:Unknown" minOccurs="0"/>
+												<xs:element name="OtherCombination" type="auc:OtherCombinationType" minOccurs="0"/>
+												<xs:element name="NoHeating" type="auc:NoHeatingType" minOccurs="0"/>
+												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -5840,9 +5844,9 @@
 														</xs:sequence>
 													</xs:complexType>
 												</xs:element>
-												<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-												<xs:element ref="auc:NoCooling" minOccurs="0"/>
-												<xs:element ref="auc:Unknown" minOccurs="0"/>
+												<xs:element name="OtherCombination" type="auc:OtherCombinationType" minOccurs="0"/>
+												<xs:element name="NoCooling" type="auc:NoCoolingType" minOccurs="0"/>
+												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -7156,9 +7160,9 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-				<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-				<xs:element ref="auc:NoHeating" minOccurs="0"/>
-				<xs:element ref="auc:Unknown" minOccurs="0"/>
+				<xs:element name="OtherCombination" type="auc:OtherCombinationType" minOccurs="0"/>
+				<xs:element name="NoHeating" type="auc:NoHeatingType" minOccurs="0"/>
+				<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="HeatingPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
 		</xs:sequence>
@@ -7431,9 +7435,9 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-				<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-				<xs:element ref="auc:NoCooling" minOccurs="0"/>
-				<xs:element ref="auc:Unknown" minOccurs="0"/>
+				<xs:element name="OtherCombination" type="auc:OtherCombinationType" minOccurs="0"/>
+				<xs:element name="NoCooling" type="auc:NoCoolingType" minOccurs="0"/>
+				<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="CoolingPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
 		</xs:sequence>
@@ -7783,7 +7787,7 @@
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="Other" minOccurs="0"/>
-				<xs:element ref="auc:Unknown" minOccurs="0"/>
+				<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="CondenserPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
 		</xs:sequence>
@@ -8064,8 +8068,8 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-						<xs:element ref="auc:Unknown" minOccurs="0"/>
+						<xs:element name="OtherCombination" type="auc:OtherCombinationType" minOccurs="0"/>
+						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -8299,12 +8303,12 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element ref="auc:Neon" minOccurs="0"/>
-						<xs:element ref="auc:Plasma" minOccurs="0"/>
-						<xs:element ref="auc:Photoluminescent" minOccurs="0"/>
-						<xs:element ref="auc:SelfLuminous" minOccurs="0"/>
-						<xs:element ref="auc:OtherCombination" minOccurs="0"/>
-						<xs:element ref="auc:Unknown" minOccurs="0"/>
+						<xs:element name="Neon" type="auc:NeonType" minOccurs="0"/>
+						<xs:element name="Plasma" type="auc:PlasmaType" minOccurs="0"/>
+						<xs:element name="Photoluminescent" type="auc:PhotoluminescentType" minOccurs="0"/>
+						<xs:element name="SelfLuminous" type="auc:SelfLuminousType" minOccurs="0"/>
+						<xs:element name="OtherCombination" type="auc:OtherCombinationType" minOccurs="0"/>
+						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -8689,7 +8693,7 @@
 																</xs:annotation>
 																<xs:complexType>
 																	<xs:choice>
-																		<xs:element ref="auc:ElectricResistance" minOccurs="0"/>
+																		<xs:element name="ElectricResistance" type="auc:ElectricResistanceType" minOccurs="0"/>
 																		<xs:element name="Combustion" minOccurs="0">
 																			<xs:complexType>
 																				<xs:sequence>
@@ -8698,7 +8702,7 @@
 																			</xs:complexType>
 																		</xs:element>
 																		<xs:element name="Other" minOccurs="0"/>
-																		<xs:element ref="auc:Unknown" minOccurs="0"/>
+																		<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 																	</xs:choice>
 																</xs:complexType>
 															</xs:element>
@@ -8869,7 +8873,7 @@
 																			</xs:complexType>
 																		</xs:element>
 																		<xs:element name="Other" minOccurs="0"/>
-																		<xs:element ref="auc:Unknown" minOccurs="0"/>
+																		<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 																	</xs:choice>
 																</xs:complexType>
 															</xs:element>
@@ -8877,7 +8881,7 @@
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Other" minOccurs="0"/>
-												<xs:element ref="auc:Unknown" minOccurs="0"/>
+												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -8977,7 +8981,7 @@
 										</xs:annotation>
 										<xs:complexType>
 											<xs:choice>
-												<xs:element ref="auc:ElectricResistance" minOccurs="0"/>
+												<xs:element name="ElectricResistance" type="auc:ElectricResistanceType" minOccurs="0"/>
 												<xs:element name="Combustion" minOccurs="0">
 													<xs:complexType>
 														<xs:sequence>
@@ -8986,7 +8990,7 @@
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Other" minOccurs="0"/>
-												<xs:element ref="auc:Unknown" minOccurs="0"/>
+												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
 									</xs:element>
@@ -8997,7 +9001,7 @@
 							<xs:complexType/>
 						</xs:element>
 						<xs:element name="Other" minOccurs="0"/>
-						<xs:element ref="auc:Unknown" minOccurs="0"/>
+						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -9848,7 +9852,7 @@
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="Other" minOccurs="0"/>
-						<xs:element ref="auc:Unknown" minOccurs="0"/>
+						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -12015,7 +12019,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="Other" minOccurs="0"/>
-												<xs:element ref="auc:Unknown" minOccurs="0"/>
+												<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -12149,7 +12153,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 							</xs:complexType>
 						</xs:element>
 						<xs:element name="Other" minOccurs="0"/>
-						<xs:element ref="auc:Unknown" minOccurs="0"/>
+						<xs:element name="Unknown" type="auc:UnknownType" minOccurs="0"/>
 					</xs:choice>
 				</xs:complexType>
 			</xs:element>
@@ -13028,7 +13032,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element ref="auc:Estimated" minOccurs="0"/>
+			<xs:element name="Estimated" type="auc:EstimatedType" minOccurs="0"/>
 			<xs:element name="Other" minOccurs="0"/>
 		</xs:choice>
 	</xs:complexType>
@@ -15083,95 +15087,68 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 			<xs:enumeration value="None"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:element name="CBECS">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="ClimateZone" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Based on the Climate Zone Type term, this is the climate zone designation.</xs:documentation>
-					</xs:annotation>
-					<xs:simpleType>
-						<xs:restriction base="xs:string">
-							<xs:enumeration value="1"/>
-							<xs:enumeration value="2"/>
-							<xs:enumeration value="3"/>
-							<xs:enumeration value="4"/>
-							<xs:enumeration value="5"/>
-						</xs:restriction>
-					</xs:simpleType>
-				</xs:element>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="ElectricResistance">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="Estimated">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="Neon">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="NoCooling">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="NoHeating">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="OtherCombination">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="Photoluminescent">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="Plasma">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="PortfolioManager">
-		<xs:annotation>
-			<xs:documentation>If exists then the data for this facility is included in Portfolio Manager.</xs:documentation>
-		</xs:annotation>
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element name="PMBenchmarkDate" type="xs:date" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Date that the building was benchmarked in Portfolio Manager. (CCYY-MM-DD)</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="BuildingProfileStatus" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>The status of the building profile submission process for Portfolio Manager.</xs:documentation>
-					</xs:annotation>
-					<xs:simpleType>
-						<xs:restriction base="xs:string">
-							<xs:enumeration value="Draft"/>
-							<xs:enumeration value="Received"/>
-							<xs:enumeration value="Under Review"/>
-							<xs:enumeration value="On Hold"/>
-							<xs:enumeration value="Reviewed and Approved"/>
-							<xs:enumeration value="Reviewed and Not Approved"/>
-						</xs:restriction>
-					</xs:simpleType>
-				</xs:element>
-				<xs:element name="FederalSustainabilityChecklistCompletionPercentage" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Percentage of the Federal High Performance Sustainability Checklist that has been completed for federal building in Portfolio Manager. (0-100)</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:simpleContent>
-							<xs:extension base="xs:decimal">
-								<xs:attribute ref="auc:Source"/>
-							</xs:extension>
-						</xs:simpleContent>
-					</xs:complexType>
-				</xs:element>
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
-	<xs:element name="SelfLuminous">
-		<xs:complexType/>
-	</xs:element>
-	<xs:element name="Unknown">
-		<xs:complexType/>
-	</xs:element>
+	<xs:complexType name="CBECSType">
+		<xs:sequence>
+			<xs:element name="ClimateZone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Based on the Climate Zone Type term, this is the climate zone designation.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="1"/>
+						<xs:enumeration value="2"/>
+						<xs:enumeration value="3"/>
+						<xs:enumeration value="4"/>
+						<xs:enumeration value="5"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ElectricResistanceType"/>
+	<xs:complexType name="EstimatedType"/>
+	<xs:complexType name="NeonType"/>
+	<xs:complexType name="NoCoolingType"/>
+	<xs:complexType name="NoHeatingType"/>
+	<xs:complexType name="OtherCombinationType"/>
+	<xs:complexType name="PhotoluminescentType"/>
+	<xs:complexType name="PlasmaType"/>
+	<xs:complexType name="PortfolioManagerType">
+		<xs:sequence>
+			<xs:element name="PMBenchmarkDate" type="xs:date" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Date that the building was benchmarked in Portfolio Manager. (CCYY-MM-DD)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BuildingProfileStatus" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The status of the building profile submission process for Portfolio Manager.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="Draft"/>
+						<xs:enumeration value="Received"/>
+						<xs:enumeration value="Under Review"/>
+						<xs:enumeration value="On Hold"/>
+						<xs:enumeration value="Reviewed and Approved"/>
+						<xs:enumeration value="Reviewed and Not Approved"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="FederalSustainabilityChecklistCompletionPercentage" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Percentage of the Federal High Performance Sustainability Checklist that has been completed for federal building in Portfolio Manager. (0-100)</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:decimal">
+							<xs:attribute ref="auc:Source"/>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SelfLuminousType"/>
+	<xs:complexType name="Unknown"/>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -5896,7 +5896,7 @@
 													</xs:complexType>
 												</xs:element>
 												<xs:element name="OtherCombination" minOccurs="0"/>
-												<xs:element name="NoCooling" minOccurs="0"/>
+												<xs:element ref="auc:NoCooling" minOccurs="0"/>
 												<xs:element name="Unknown" minOccurs="0"/>
 											</xs:choice>
 										</xs:complexType>
@@ -7487,7 +7487,7 @@
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="OtherCombination" minOccurs="0"/>
-				<xs:element name="NoCooling" minOccurs="0"/>
+				<xs:element ref="auc:NoCooling" minOccurs="0"/>
 				<xs:element name="Unknown" minOccurs="0"/>
 			</xs:choice>
 			<xs:element name="CoolingPlantCondition" type="auc:EquipmentCondition" minOccurs="0"/>
@@ -15134,4 +15134,5 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 			<xs:enumeration value="None"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:element name="NoCooling" type="xs:string" fixed=""/>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -8354,7 +8354,7 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="Neon" minOccurs="0"/>
+						<xs:element ref="auc:Neon" minOccurs="0"/>
 						<xs:element name="Plasma" minOccurs="0"/>
 						<xs:element name="Photoluminescent" minOccurs="0"/>
 						<xs:element name="SelfLuminous" minOccurs="0"/>
@@ -15134,6 +15134,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 			<xs:enumeration value="None"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:element name="Neon">
+		<xs:complexType/>
+	</xs:element>
 	<xs:element name="NoCooling">
 		<xs:complexType/>
 	</xs:element>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -13016,7 +13016,9 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
-									<xs:element name="DirectMeasurement" minOccurs="0"/>
+									<xs:element name="DirectMeasurement" minOccurs="0">
+										<xs:complexType/>
+									</xs:element>
 									<xs:element name="Other" minOccurs="0"/>
 								</xs:choice>
 							</xs:complexType>


### PR DESCRIPTION
This PR addresses the issues with the `BuildingSync.xsd` file that have been identified with the use of automated code generation tools (e.g., the `xsd2ruby.rb` script from the https://github.com/rubyjedi/soap4r gem).

Specifically, types are defined for the following XML elements:
* `auc:CBECS`
* `auc:CriticalPeakPricing`
* `auc:CriticalPeakRebates`
* `auc:DirectMeasurement`
* `auc:ElectricResistance`
* `auc:Estimated`
* `auc:HeatExchanger`
* `auc:Neon`
* `auc:NoCooling`
* `auc:NoHeating`
* `auc:Other`
* `auc:OtherCombination`
* `auc:Photoluminescent`
* `auc:Plasma`
* `auc:PortfiolioManager`
* `auc:RealTimePricing`
* `auc:SelfLuminous`
* `auc:Unknown`
* `auc:VariablePeakPricingOther`
