### PR TITLE
Add IDref attribute to "*ID" XML elements

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -8147,10 +8147,13 @@
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:element>
-			<xs:element name="LinkedDeliveryID" type="xs:IDREF" minOccurs="0">
+			<xs:element name="LinkedDeliveryID" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Connect to an air distribution system</xs:documentation>
 				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
+				</xs:complexType>
 			</xs:element>
 			<xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
 			<xs:element ref="auc:Quantity" minOccurs="0"/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6074,7 +6074,11 @@
 																							</xs:restriction>
 																						</xs:simpleType>
 																					</xs:element>
-																					<xs:element name="ReheatPlantID" type="xs:IDREF" minOccurs="0"/>
+																					<xs:element name="ReheatPlantID" minOccurs="0">
+																						<xs:complexType>
+																							<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
+																						</xs:complexType>
+																					</xs:element>
 																				</xs:sequence>
 																			</xs:complexType>
 																		</xs:element>

--- a/examples/PrimarySchoolCRB1.xml
+++ b/examples/PrimarySchoolCRB1.xml
@@ -3476,7 +3476,7 @@
 											<AirDeliveryType>Central fan</AirDeliveryType>
 											<TerminalUnit>VAV terminal box not fan powered with reheat</TerminalUnit>
 											<ReheatSource>Heating plant</ReheatSource>
-											<ReheatPlantID>Boiler1</ReheatPlantID>
+											<ReheatPlantID IDref="Boiler1"/>
 										</CentralAirDistribution>
 									</FanBasedDistributionType>
 									<AirSideEconomizer>
@@ -3501,7 +3501,7 @@
 											<AirDeliveryType>Central fan</AirDeliveryType>
 											<TerminalUnit>VAV terminal box not fan powered with reheat</TerminalUnit>
 											<ReheatSource>Heating plant</ReheatSource>
-											<ReheatPlantID>Boiler1</ReheatPlantID>
+											<ReheatPlantID IDref="Boiler1"/>
 										</CentralAirDistribution>
 									</FanBasedDistributionType>
 									<AirSideEconomizer>
@@ -3526,7 +3526,7 @@
 											<AirDeliveryType>Central fan</AirDeliveryType>
 											<TerminalUnit>VAV terminal box not fan powered with reheat</TerminalUnit>
 											<ReheatSource>Heating plant</ReheatSource>
-											<ReheatPlantID>Boiler1</ReheatPlantID>
+											<ReheatPlantID IDref="Boiler1"/>
 										</CentralAirDistribution>
 									</FanBasedDistributionType>
 									<AirSideEconomizer>
@@ -3551,7 +3551,7 @@
 											<AirDeliveryType>Central fan</AirDeliveryType>
 											<TerminalUnit>VAV terminal box not fan powered with reheat</TerminalUnit>
 											<ReheatSource>Heating plant</ReheatSource>
-											<ReheatPlantID>Boiler1</ReheatPlantID>
+											<ReheatPlantID IDref="Boiler1"/>
 										</CentralAirDistribution>
 									</FanBasedDistributionType>
 									<AirSideEconomizer>

--- a/examples/PrimarySchoolCRB1.xml
+++ b/examples/PrimarySchoolCRB1.xml
@@ -3652,7 +3652,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod1</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod1"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone2">
 							<OtherHVACType>
@@ -3673,7 +3673,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod1</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod1"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone3">
 							<OtherHVACType>
@@ -3693,7 +3693,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod1</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod1"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone4">
 							<OtherHVACType>
@@ -3713,7 +3713,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod1</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod1"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone5">
 							<OtherHVACType>
@@ -3733,7 +3733,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod1</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod1"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone6">
 							<OtherHVACType>
@@ -3753,7 +3753,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod2</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod2"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone7">
 							<OtherHVACType>
@@ -3773,7 +3773,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod2</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod2"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone8">
 							<OtherHVACType>
@@ -3793,7 +3793,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod2</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod2"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone9">
 							<OtherHVACType>
@@ -3813,7 +3813,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod2</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod2"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone10">
 							<OtherHVACType>
@@ -3833,7 +3833,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod2</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod2"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone11">
 							<OtherHVACType>
@@ -3853,7 +3853,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod3</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod3"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone12">
 							<OtherHVACType>
@@ -3873,7 +3873,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod3</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod3"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone13">
 							<OtherHVACType>
@@ -3893,7 +3893,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod3</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod3"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone14">
 							<OtherHVACType>
@@ -3913,7 +3913,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod3</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod3"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone15">
 							<OtherHVACType>
@@ -3933,7 +3933,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod3</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod3"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone16">
 							<OtherHVACType>
@@ -3953,7 +3953,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryPod3</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryPod3"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone17">
 							<OtherHVACType>
@@ -3973,7 +3973,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryOther</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryOther"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone18">
 							<OtherHVACType>
@@ -3993,7 +3993,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryOther</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryOther"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone19">
 							<OtherHVACType>
@@ -4013,7 +4013,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryOther</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryOther"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone20">
 							<OtherHVACType>
@@ -4033,7 +4033,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryOther</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryOther"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone21">
 							<OtherHVACType>
@@ -4053,7 +4053,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryOther</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryOther"/>
 						</OtherHVACSystem>
 						<OtherHVACSystem ID="VentZone25">
 							<OtherHVACType>
@@ -4073,7 +4073,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with central air distribution</Integration>
-							<LinkedDeliveryID>DeliveryOther</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="DeliveryOther"/>
 						</OtherHVACSystem>
 					</OtherHVACSystems>
 					<Priority>Primary</Priority>
@@ -4173,7 +4173,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with local air distribution</Integration>
-							<LinkedDeliveryID>GymDelivery</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="GymDelivery"/>
 						</OtherHVACSystem>
 					</OtherHVACSystems>
 					<Priority>Primary</Priority>
@@ -4275,7 +4275,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with local air distribution</Integration>
-							<LinkedDeliveryID>KitchenDelivery</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="KitchenDelivery"/>
 						</OtherHVACSystem>
 					</OtherHVACSystems>
 					<Priority>Primary</Priority>
@@ -4375,7 +4375,7 @@
 								</ThermalZone>
 							</LinkedPremises>
 							<Integration>Integrated with local air distribution</Integration>
-							<LinkedDeliveryID>CafeteriaDelivery</LinkedDeliveryID>
+							<LinkedDeliveryID IDref="CafeteriaDelivery"/>
 						</OtherHVACSystem>
 					</OtherHVACSystems>
 					<Priority>Primary</Priority>


### PR DESCRIPTION
This PR adds "IDref" attributes to the `<auc:LinkedDeliveryID>` and `<auc:ReheatPlantID>` XML elements.

The intent of this PR is that "*ID" XML elements have common structure (e.g., an "IDref" attribute).