### PR TITLE
Add FloorAreas to LinkedPremises

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -13485,6 +13485,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 												<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 											</xs:complexType>
 										</xs:element>
+										<xs:element ref="auc:FloorAreas" minOccurs="0"/>
 									</xs:sequence>
 									<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 								</xs:complexType>
@@ -13509,6 +13510,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 												<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 											</xs:complexType>
 										</xs:element>
+										<xs:element ref="auc:FloorAreas" minOccurs="0"/>
 									</xs:sequence>
 									<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 								</xs:complexType>
@@ -13533,6 +13535,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 												<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 											</xs:complexType>
 										</xs:element>
+										<xs:element ref="auc:FloorAreas" minOccurs="0"/>
 									</xs:sequence>
 									<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 								</xs:complexType>
@@ -13557,6 +13560,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 												<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 											</xs:complexType>
 										</xs:element>
+										<xs:element ref="auc:FloorAreas" minOccurs="0"/>
 									</xs:sequence>
 									<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 								</xs:complexType>
@@ -13581,6 +13585,7 @@ Window spacing: the dimension between windows in a discrete window layout. (in.)
 												<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 											</xs:complexType>
 										</xs:element>
+										<xs:element ref="auc:FloorAreas" minOccurs="0"/>
 									</xs:sequence>
 									<xs:attribute name="IDref" type="xs:IDREF" use="required"/>
 								</xs:complexType>

--- a/examples/Multi-Facility Shared Systems.xml
+++ b/examples/Multi-Facility Shared Systems.xml
@@ -128,8 +128,33 @@
 					</EnergyConversionType>
 					<LinkedPremises>
 						<Facility>
-							<LinkedFacilityID IDref="Building1"/>
-							<LinkedFacilityID IDref="Building2"/>
+							<LinkedFacilityID IDref="Building1">
+								<FloorAreas>
+									<FloorArea>
+										<FloorAreaType>Conditioned</FloorAreaType>
+										<FloorAreaPercentage>100</FloorAreaPercentage>
+									</FloorArea>
+								</FloorAreas>
+							</LinkedFacilityID>
+							<LinkedFacilityID IDref="Building2">
+								<FloorAreas>
+									<FloorArea>
+										<FloorAreaType>Gross</FloorAreaType>
+										<FloorAreaPercentage>25</FloorAreaPercentage>
+										<Story>1</Story>
+									</FloorArea>
+									<FloorArea>
+										<FloorAreaType>Gross</FloorAreaType>
+										<FloorAreaPercentage>50</FloorAreaPercentage>
+										<Story>2</Story>
+									</FloorArea>
+									<FloorArea>
+										<FloorAreaType>Gross</FloorAreaType>
+										<FloorAreaPercentage>50</FloorAreaPercentage>
+										<Story>3</Story>
+									</FloorArea>
+								</FloorAreas>
+							</LinkedFacilityID>
 						</Facility>
 					</LinkedPremises>
 				</OnSiteStorageTransmissionGenerationSystem>


### PR DESCRIPTION
Add a a floor area element to each of the linkage subelements of the linked premises element. This will allow users to specify a absolute or percentage area associated with the linkage. For systems and equipment, this makes sense. I'm not sure it makes sense everywhere that the linked premises concept is used, so before this is merged that will need to be checked.

It's a relatively small change in terms of the diff and it is non-breaking.