### PR TITLE
Remove Double Dash in Annotations

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3195,22 +3195,22 @@
                               </xs:element>
                               <xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date from which the rate is applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date after which the rate is not applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="ApplicableStartDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date from which the rate is applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="ApplicableEndDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date after which the rate is not applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="DemandWindow" minOccurs="0">
@@ -3319,22 +3319,22 @@
                               </xs:element>
                               <xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date from which the rate is applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date after which the rate is not applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="ApplicableStartDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date from which the rate is applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="ApplicableEndDateForDemandRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date after which the rate is not applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="TimeOfUsePeriod" minOccurs="0" maxOccurs="unbounded">
@@ -3474,12 +3474,12 @@
                               </xs:element>
                               <xs:element name="ApplicableStartDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date from which the rate is applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date from which the rate is applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="ApplicableEndDateForEnergyRate" type="xs:gMonthDay" minOccurs="0">
                                 <xs:annotation>
-                                  <xs:documentation>The date after which the rate is not applicable. (--MM-DD)</xs:documentation>
+                                  <xs:documentation>The date after which the rate is not applicable. (MM-DD)</xs:documentation>
                                 </xs:annotation>
                               </xs:element>
                               <xs:element name="RateTier" minOccurs="0" maxOccurs="unbounded">

--- a/docs/release_instructions.md
+++ b/docs/release_instructions.md
@@ -1,14 +1,30 @@
 # Releasing
 
-When releasing new versions, make sure to do the following:
+Follow the steps below when releasing a new version
 
 * Update the Version in the header of the XSD with the release date
 (e.g. Version 0.2 (November 5, 2017))
-* (Optional) Convert XSD to JSON schema. This is still in prototype. 
-* Update the Changelog to include the latest changes, and the most 
-recent version. Easiest to run the change_log.rb script (e.g. ruby src/change_log.rb -t abcdefghijklmnopqrstuvwxyz -s <last-release-data>).
-* After merging down the release into the main branch, draft a release in Github. Upload the XSD and JSON file as part of the release.
-* Copy the schema to the website-schemas repo with documentation. Note that this is not what we really want to do anymore. (website-schema repo here: https://github.com/BuildingSync/website-schemas)
-* Add links ot the index.md in the root of website-schemas repo
-* In the website repo update the docs/schema/index.md to include the 
-new release.
+
+* (Optional) Convert XSD to JSON schema. This is still in prototype. Use XMLSpy to Generate JSON Schema (use default options).
+
+* Ensure that the XSD and JSON Schema have spaces, and not tabs.
+
+* Update the CHANGELOG to include the latest changes, and the most recent version.
+
+	* Run the change_log.rb script (e.g. ruby src/change_log.rb -t abcdefghijklmnopqrstuvwxyz -s <last-release-data>).
+	* Copy the results of this into the CHANGELOG. Remove items that are not useful to an end user such as version bumps, formatting, etc.
+
+* After merging down the release into the main branch, draft a release in GitHub. Upload the XSD and JSON file as part of the release.
+
+* Use xs3p to generate the documentation. .
+
+	* Download [V1.1.5](https://sourceforge.net/projects/xs3p/) and unzip.
+	* Run `xsltproc xs3p.xsl <path-to-BuildingSync.xsd> > index.html` to generate the new html documentation. Note that xsltproc may need to be installed on your machine to run.
+
+* Edit the BuildingSync Website GitHub repo on a new branch (https://github.com/BuildingSync/website):
+
+	* Add generated documentation under /documents/schema/documentation/<new_version>
+	* Update /documents/schema/index.md to include new release, follow existing pattern.
+
+* Create a Pull Request from the new branch to gh-pages.
+


### PR DESCRIPTION
xs3p documentation generation was failing due to the double dash in the annotations (--MM-DD). This removes the double dash and just makes the annotation (MM-DD).