### PR TITLE
AirInfiltrationSystem ID, UDF on Package of Measures, enums on GenTech, OccClass, and PlugLoad

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -308,6 +308,7 @@
                                       <xs:element ref="auc:LinkedPremises" minOccurs="0"/>
                                       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
                                     </xs:sequence>
+                                    <xs:attribute name="ID" type="xs:ID"/>
                                   </xs:complexType>
                                 </xs:element>
                               </xs:sequence>
@@ -2836,6 +2837,7 @@
                   </xs:element>
                   <xs:element ref="auc:AssetScore" minOccurs="0"/>
                   <xs:element ref="auc:ENERGYSTARScore" minOccurs="0"/>
+                  <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
@@ -12617,6 +12619,9 @@
             <xs:enumeration value="Display"/>
             <xs:enumeration value="Set Top Box"/>
             <xs:enumeration value="Business Equipment"/>
+            <xs:enumeration value="Broadcast Antenna"/>
+            <xs:enumeration value="Kitchen Equipment"/>
+            <xs:enumeration value="Signage Display"/>
             <xs:enumeration value="Miscellaneous Electric Load"/>
             <xs:enumeration value="Other"/>
             <xs:enumeration value="Unknown"/>
@@ -13039,6 +13044,7 @@
                                     <xs:enumeration value="Standby generator"/>
                                     <xs:enumeration value="Turbine"/>
                                     <xs:enumeration value="Microturbine"/>
+                                    <xs:enumeration value="Reciprocating engine"/>
                                     <xs:enumeration value="Fuel cell"/>
                                     <xs:enumeration value="Gasification"/>
                                     <xs:enumeration value="Binary Cycle"/>
@@ -14765,6 +14771,8 @@
         <xs:enumeration value="Refrigerated storage"/>
         <xs:enumeration value="Bar"/>
         <xs:enumeration value="Dance floor"/>
+        <xs:enumeration value="Trading floor"/>
+        <xs:enumeration value="TV studio"/>
         <xs:enumeration value="Security room"/>
         <xs:enumeration value="Shipping and receiving"/>
         <xs:enumeration value="Mechanical room"/>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2016 (x64) (http://www.altova.com) by kflemin (NREL) -->
 <!--This example file is meant to cover the majority of the functionality of New York Local Law 87-->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>
@@ -193,12 +194,24 @@
             <YearInstalled>1999</YearInstalled>
           </RoofSystem>
         </RoofSystems>
+        <PlugLoads>
+          <PlugLoad>
+            <PlugLoadType>Signage Display</PlugLoadType>
+            <LinkedPremises>
+              <Facility>
+                <LinkedFacilityID IDref="Facility1"/>
+              </Facility>
+            </LinkedPremises>
+          </PlugLoad>
+        </PlugLoads>
         <OnSiteStorageTransmissionGenerationSystems>
           <OnSiteStorageTransmissionGenerationSystem ID="AllThePV">
             <EnergyConversionType>
               <Generation>
                 <OnSiteGenerationType>
-                  <PV/>
+                  <Other>
+                    <OtherEnergyGenerationTechnology>Reciprocating engine</OtherEnergyGenerationTechnology>
+                  </Other>
                 </OnSiteGenerationType>
               </Generation>
             </EnergyConversionType>
@@ -210,6 +223,15 @@
             </LinkedPremises>
           </OnSiteStorageTransmissionGenerationSystem>
         </OnSiteStorageTransmissionGenerationSystems>
+        <AirInfiltrationSystems>
+          <AirInfiltrationSystem ID="AirInfiltrationSystem1">
+            <LinkedPremises>
+              <Facility>
+                <LinkedFacilityID IDref="Facility1"/>
+              </Facility>
+            </LinkedPremises>
+          </AirInfiltrationSystem>
+        </AirInfiltrationSystems>
       </Systems>
       <Measures>
         <Measure ID="Building1RemovePV">
@@ -261,6 +283,12 @@
                   <MeasureIDs>
                     <MeasureID IDref="WholeSiteRemovePV"/>
                   </MeasureIDs>
+                  <UserDefinedFields>
+                    <UserDefinedField>
+                      <FieldName>TestUDF</FieldName>
+                      <FieldValue>tested</FieldValue>
+                    </UserDefinedField>
+                  </UserDefinedFields>
                 </PackageOfMeasures>
               </ScenarioType>
             </Scenario>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2016 (x64) (http://www.altova.com) by kflemin (NREL) -->
 <!--This example file is meant to cover the majority of the functionality of New York Local Law 87-->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>

--- a/proposals/2019/Add ID to AirInfiltrationSystem.md
+++ b/proposals/2019/Add ID to AirInfiltrationSystem.md
@@ -1,0 +1,18 @@
+# OccupancyClassification - Add Enumerations
+
+## Overview
+
+AirInfiltrationSystem element does not have an ID element.  Most other "system" elements do.
+
+## Justification
+
+There exists a need to have an ID attribute on the AirInfiltrationSystem element.
+
+## Implementation
+
+This proposal is to add an ID attribute to path: 
+BuildingSync/Facilities/Facility/Systems/AirInfiltrationSystems/AirInfiltrationSystem
+
+## References
+
+N/A

--- a/proposals/2019/Add PlugLoadType enums.md
+++ b/proposals/2019/Add PlugLoadType enums.md
@@ -1,0 +1,25 @@
+# PlugLoadType - Add Enumerations
+
+## Overview
+
+PlugLoadType is missing useful enumerations.
+
+## Justification
+
+There exists a need for certain users to have additional PlugLoadType enumerations:  Broadcast antenna, Kitchen equipment, and Signage display.
+
+Signage display in this case is to accomodate a "Times Square Sign".
+
+## Implementation
+
+This proposal is to:
+Add the following enumerations to path: 
+BuildingSync/Facilities/Facility/Systems/PlugLoads/PlugLoad/PlugLoadType
+
+1. Broadcast antenna
+2. Kitchen equipment
+3. Signage display
+
+## References
+
+N/A

--- a/proposals/2019/Add UDF to PackageOfMeasures.md
+++ b/proposals/2019/Add UDF to PackageOfMeasures.md
@@ -1,0 +1,24 @@
+# PackageOfMeasures - Add UserDefinedFields
+
+## Overview
+
+PackageOfMeasures does not have UserDefinedFields.
+
+## Justification
+
+There exists a need for certain users to add user-defined fields on PackageOfMeasures
+
+## Implementation
+
+This proposal is to:
+
+Add the following elements under BuildingSync/Facilities/Facility/Reports/Report/Scenarios/Scenario/ScenarioType/PackageOfMeasures:
+
+	1. UserDefinedFields
+	2. UserDefinedFields/UserDefinedField
+	3. UserDefinedFields/UserDefinedField/FieldName
+	4. UserDefinedFields/UserDefinedField/FieldValue
+
+## References
+
+N/A

--- a/proposals/2019/OccupancyClassification.md
+++ b/proposals/2019/OccupancyClassification.md
@@ -1,0 +1,20 @@
+# OccupancyClassification - Add Enumerations
+
+## Overview
+
+<auc:OccupancyClassification> enumeration does not have “Trading floor” or “TV studio” values.
+
+## Justification
+
+There exists a need for certain users to have additional enumerations added to OccupancyClassification.
+
+## Implementation
+
+This proposal is to:
+Add the following enumerations to OccupancyClassification:
+Trading floor
+TV studio
+
+## References
+
+N/A

--- a/proposals/2019/OtherEnergyGenerationTechnology.md
+++ b/proposals/2019/OtherEnergyGenerationTechnology.md
@@ -1,0 +1,19 @@
+# OtherEnergyGenerationTechnology - Add Enumeration
+
+## Overview
+
+OtherEnergyGenerationTechnology enumeration does not have “Reciprocating engine".
+
+## Justification
+
+There exists a need for certain users to have an additional enumeration.
+
+## Implementation
+
+This proposal is to:
+Add the enumeration "Reciprocating engine" to the path 
+BuildingSync/Facilities/Facility/Systems/OnSiteStorageTransmissionGenerationSystems/OnSiteStorageTransmissionGenerationSystem/EnergyConversionType/Generation/OnSiteGenerationType/Other/OtherEnergyGenerationTechnology
+
+## References
+
+N/A


### PR DESCRIPTION
1. <auc:AirInfiltrationSystem> does not have @ID attribute.
2. <auc:PackageOfMeasures> element does not have <auc:UserDefinedFields> child element.
3. <auc:OtherEnergyGenerationTechnology> does not have “Reciprocating engine” value.
4. <auc:OccupancyClassification> enumeration does not have “Trading floor” or “TV studio” values.
5. <auc:PlugLoadType> enumeration does not have “Broadcast antenna”, “Kitchen equipment” and “Times Square sign” values.

All changes have examples in LL87.xml example file except for #4.