### PR TITLE
FanBased Optional

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6522,7 +6522,7 @@
                                 </xs:annotation>
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="FanBased" type="auc:FanBasedType"/>
+                                    <xs:element name="FanBased" type="auc:FanBasedType" minOccurs="0"/>
                                     <xs:element name="Convection" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -110,7 +110,7 @@
             </Plants>
             <HeatingAndCoolingSystems>
               <HeatingSources>
-                <HeatingSource>
+                <HeatingSource ID="HeatingSource1">
                   <HeatingSourceType>
                     <SourceHeatingPlantID IDref="HeatingPlant1"/>
                   </HeatingSourceType>
@@ -121,10 +121,23 @@
               <Deliveries>
                 <Delivery>
                   <DeliveryType>
-                    <CentralAirDistribution>
-                      <TerminalUnit>Powered induction unit</TerminalUnit>
-                    </CentralAirDistribution>
+                    <ZoneEquipment>
+                      <Radiant>
+                        <RadiantType>Radiator</RadiantType>
+                      </Radiant>
+                    </ZoneEquipment>
                   </DeliveryType>
+                  <PrimaryFuel>Electricity</PrimaryFuel>
+                </Delivery>
+                <Delivery>
+                  <DeliveryType>
+                    <ZoneEquipment>
+                      <Radiant>
+                        <RadiantType>Radiator</RadiantType>
+                      </Radiant>
+                    </ZoneEquipment>
+                  </DeliveryType>
+                  <HeatingSourceID IDref="HeatingSource1"/>
                 </Delivery>
               </Deliveries>
             </HeatingAndCoolingSystems>
@@ -164,7 +177,7 @@
             </Plants>
             <HeatingAndCoolingSystems>
               <CoolingSources>
-                <CoolingSource>
+                <CoolingSource ID="CoolingSource1">
                   <CoolingSourceType>
                     <CoolingPlantID IDref="CoolingPlant1"/>
                   </CoolingSourceType>
@@ -172,6 +185,16 @@
                   <PrimaryFuel>Fuel oil no 2</PrimaryFuel>
                 </CoolingSource>
               </CoolingSources>
+              <Deliveries>
+                <Delivery>
+                  <DeliveryType>
+                    <CentralAirDistribution>
+                      <TerminalUnit>Powered induction unit</TerminalUnit>
+                    </CentralAirDistribution>
+                  </DeliveryType>
+                  <CoolingSourceID IDref="CoolingSource1"/>
+                </Delivery>
+              </Deliveries>
             </HeatingAndCoolingSystems>
             <LinkedPremises>
               <Building>

--- a/proposals/2019/Make FanBased Optional.md
+++ b/proposals/2019/Make FanBased Optional.md
@@ -1,0 +1,20 @@
+# Make FanBased ZoneEquipment Optional
+
+## Overview
+
+The fan based zone equipment object was set to be required. If a building has only radiant panels, then this requirement is not necessary.
+
+## Justification
+
+A user needs to be able to specify a radiant system without a fan based system
+
+## Implementation
+
+Add `minOccurs="0"` to FanBasedType
+
+This is a non-breaking change.
+
+## References
+
+N/A
+


### PR DESCRIPTION
This PR make FanBased optional which is a simple non-breaking change. The LL87 example file has been updated to demonstrate how to specify zone-based radiant systems (hot water and electrical).

