### PR TITLE
fixing enums for SimulationCompletionStatus

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -13481,9 +13481,8 @@
                 <xs:restriction base="xs:string">
                   <xs:enumeration value="Not Started"/>
                   <xs:enumeration value="Started"/>
-                  <xs:enumeration value="Queued"/>
                   <xs:enumeration value="Finished"/>
-                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="Failed"/>
                   <xs:enumeration value="Unknown"/>
                 </xs:restriction>
               </xs:simpleType>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -350,7 +350,7 @@
                   <CalculationMethod>
                     <Modeled>
                       <WeatherDataType>TMY</WeatherDataType>
-                      <SimulationCompletionStatus>Not Started</SimulationCompletionStatus>
+                      <SimulationCompletionStatus>Finished</SimulationCompletionStatus>
                     </Modeled>
                   </CalculationMethod>
                   <UserDefinedFields>


### PR DESCRIPTION
Fixed enums on SimulationCompletionStatus to represent status of simulation (whether the simulation was run or not) as well as the success of the run (Finished = finished successfully; Failed = finished but with errors)