### PR TITLE
Controls refactor

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6935,6 +6935,11 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
+      <xs:element name="PrimaryHVACControls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The main types of HVAC controls that are used for this system.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="PrimaryHVACControlStrategy" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Primary HVAC equipment control strategy.</xs:documentation>
@@ -6942,7 +6947,7 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:enumeration value="Pneumatic"/>
-            <xs:enumeration value="Electric"/>
+            <xs:enumeration value="Electronic"/>
             <xs:enumeration value="Other"/>
             <xs:enumeration value="Unknown"/>
           </xs:restriction>
@@ -8886,7 +8891,7 @@
       </xs:element>
       <xs:element name="LightingControlTypeOccupancy" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Type of occupancy controls used to manage lighting.</xs:documentation>
+          <xs:documentation>Type of occupancy controls used to manage lighting. - Will move to LightingControl</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -8900,7 +8905,7 @@
       </xs:element>
       <xs:element name="LightingControlTypeTimer" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Type of timer controls used to manage lighting.</xs:documentation>
+          <xs:documentation>Type of timer controls used to manage lighting.  - Will move to lighting control.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -8914,7 +8919,7 @@
       </xs:element>
       <xs:element name="LightingControlTypeDaylighting" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Type of daylighting controls used to manage lighting.</xs:documentation>
+          <xs:documentation>Type of daylighting controls used to manage lighting. - Will move to lighting control</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -8930,7 +8935,7 @@
       </xs:element>
       <xs:element name="LightingControlTypeManual" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Type of manual controls used to manage lighting.</xs:documentation>
+          <xs:documentation>Type of manual controls used to manage lighting. -Will move to lighting control.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -8975,18 +8980,6 @@
               </xs:complexType>
             </xs:element>
           </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="DaylightingControlSteps" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>For stepped dimming, the number of equally spaced control steps</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-          <xs:simpleContent>
-            <xs:extension base="xs:integer">
-              <xs:attribute ref="auc:Source"/>
-            </xs:extension>
-          </xs:simpleContent>
         </xs:complexType>
       </xs:element>
       <xs:element name="PercentPremisesServed" minOccurs="0">
@@ -9150,6 +9143,680 @@
               <xs:attribute ref="auc:Source"/>
             </xs:extension>
           </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Controls_1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlOptionType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Type of control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Controls_2">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="HVACControl" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Type of control.</xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Pneumatic" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="ControlTechnology" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="Thermostat" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Other" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="Analog" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="CommunicationProtocol" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="0-10V"/>
+                              <xs:enumeration value="4-20mA"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ControlTechnology" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="Thermostat" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Timer" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Astronomical"/>
+                                          <xs:enumeration value="Chronological"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Other" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="DirectDigitalControl" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="CommunicationProtocol" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="BACnet"/>
+                              <xs:enumeration value="Konnex"/>
+                              <xs:enumeration value="LonTalk"/>
+                              <xs:enumeration value="MODBUS"/>
+                              <xs:enumeration value="PROFIBUS FMS"/>
+                              <xs:enumeration value="ZibBee"/>
+                              <xs:enumeration value="Unknown"/>
+                              <xs:enumeration value="Other"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ControlTechnology" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="ECMS" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Thermostat" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Timer" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Chronological"/>
+                                          <xs:enumeration value="Astronomical"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Other" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="Other" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="OtherControlType" type="xs:string" minOccurs="0"/>
+                        <xs:element name="ControlTechnology" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="AdvancedPowerStrip" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="ECMS" minOccurs="0"/>
+                              <xs:element name="None" minOccurs="0"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="LightingControl" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Analog" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="CommunicationProtocol" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="0-10V"/>
+                              <xs:enumeration value="AMX192"/>
+                              <xs:enumeration value="D54"/>
+                              <xs:enumeration value="Other"/>
+                              <xs:enumeration value="Unknown"/>
+                              <xs:enumeration value="None"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ControlTechnology" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="Daylighting" minOccurs="0">
+                                <xs:annotation>
+                                  <xs:documentation>Type of daylighting controls used to manage lighting.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Continuous"/>
+                                          <xs:enumeration value="Continuous Plus Off"/>
+                                          <xs:enumeration value="Stepped Dimming"/>
+                                          <xs:enumeration value="Stepped Switching"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="ControlSteps" minOccurs="0">
+                                      <xs:annotation>
+                                        <xs:documentation>For stepped dimming, the number of equally spaced control steps.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:complexType>
+                                        <xs:simpleContent>
+                                          <xs:extension base="xs:integer">
+                                            <xs:attribute ref="auc:Source"/>
+                                          </xs:extension>
+                                        </xs:simpleContent>
+                                      </xs:complexType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Manual" minOccurs="0">
+                                <xs:annotation>
+                                  <xs:documentation>Type of manual controls used to manage lighting.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStategy">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Manual On/Off"/>
+                                          <xs:enumeration value="Manual Dimming"/>
+                                          <xs:enumeration value="Bi-level Control"/>
+                                          <xs:enumeration value="Tri-level Control"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Occupancy" minOccurs="0">
+                                <xs:annotation>
+                                  <xs:documentation>Type of occupancy controls used to manage lighting.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Occupancy Sensors"/>
+                                          <xs:enumeration value="Vacancy Sensors"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Other" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Advanced"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="Digital" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="CommunicationProtocol" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="BACnet"/>
+                              <xs:enumeration value="Konnex"/>
+                              <xs:enumeration value="LonTalk"/>
+                              <xs:enumeration value="MODBUS"/>
+                              <xs:enumeration value="PROFIBUS FMS"/>
+                              <xs:enumeration value="ZibBee"/>
+                              <xs:enumeration value="Unknown"/>
+                              <xs:enumeration value="Other"/>
+                              <xs:enumeration value="DALI"/>
+                              <xs:enumeration value="DSI "/>
+                              <xs:enumeration value="DMX512"/>
+                              <xs:enumeration value="KMX"/>
+                              <xs:enumeration value="EnOcean"/>
+                              <xs:enumeration value="X10"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                        <xs:element name="ControlTechnology" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="AdvancedPowerStrip" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Daylighting" minOccurs="0">
+                                <xs:annotation>
+                                  <xs:documentation>Type of daylighting controls used to manage lighting.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Continuous"/>
+                                          <xs:enumeration value="Continuous Plus Off"/>
+                                          <xs:enumeration value="Stepped Dimming"/>
+                                          <xs:enumeration value="Stepped Switching"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                    <xs:element name="ControlSteps" minOccurs="0">
+                                      <xs:annotation>
+                                        <xs:documentation>For stepped dimming, the number of equally spaced control steps.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:complexType>
+                                        <xs:simpleContent>
+                                          <xs:extension base="xs:integer">
+                                            <xs:attribute ref="auc:Source"/>
+                                          </xs:extension>
+                                        </xs:simpleContent>
+                                      </xs:complexType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="ECMS" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Always On"/>
+                                          <xs:enumeration value="Aquastat"/>
+                                          <xs:enumeration value="Demand"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Manual" minOccurs="0">
+                                <xs:annotation>
+                                  <xs:documentation>Type of manual controls used to manage lighting.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStategy">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Manual On/Off"/>
+                                          <xs:enumeration value="Manual Dimming"/>
+                                          <xs:enumeration value="Bi-level Control"/>
+                                          <xs:enumeration value="Tri-level Control"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Occupancy" minOccurs="0">
+                                <xs:annotation>
+                                  <xs:documentation>Type of occupancy controls used to manage lighting.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Occupancy Sensors"/>
+                                          <xs:enumeration value="Vacancy Sensors"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Timer" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Chronological"/>
+                                          <xs:enumeration value="Astronomical"/>
+                                          <xs:enumeration value="Manual"/>
+                                          <xs:enumeration value="Programmable"/>
+                                          <xs:enumeration value="Scheduled"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="None"/>
+                                          <xs:enumeration value="Unknown"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                              <xs:element name="Other" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ControlStrategy">
+                                      <xs:annotation>
+                                        <xs:documentation>Controller strategy.</xs:documentation>
+                                      </xs:annotation>
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Advanced"/>
+                                          <xs:enumeration value="Other"/>
+                                          <xs:enumeration value="Unknown"/>
+                                          <xs:enumeration value="None"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="Other" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
@@ -16426,4 +17093,79 @@
       <xs:documentation>Year that the burner was installed</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:complexType name="ControlOptionType">
+    <xs:sequence>
+      <xs:element name="ControllerType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The type of controller. E.g., electronic, pneumatic.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="Analog"/>
+            <xs:enumeration value="Direct digital control"/>
+            <xs:enumeration value="Pneumatic"/>
+            <xs:enumeration value="Other"/>
+            <xs:enumeration value="Unknown"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="CommunicationProtocol" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="0-10V"/>
+            <xs:enumeration value="BACnet"/>
+            <xs:enumeration value="Konnex"/>
+            <xs:enumeration value="LonTalk"/>
+            <xs:enumeration value="MODBUS"/>
+            <xs:enumeration value="PROFIBUS FMS"/>
+            <xs:enumeration value="ZibBee"/>
+            <xs:enumeration value="Unknown"/>
+            <xs:enumeration value="Other"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="ControlTechnology" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Technological device that enables control of the system.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="Advanced power strip"/>
+            <xs:enumeration value="EMCS"/>
+            <xs:enumeration value="Thermostat"/>
+            <xs:enumeration value="Thermostatic radiator valve"/>
+            <xs:enumeration value="Thermostatic zone valve"/>
+            <xs:enumeration value="Timer"/>
+            <xs:enumeration value="Other"/>
+            <xs:enumeration value="Unknown"/>
+            <xs:enumeration value="None"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="ControlStrategy" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The strategy used to control the system.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="Always On"/>
+            <xs:enumeration value="Astronomical"/>
+            <xs:enumeration value="Aquastat"/>
+            <xs:enumeration value="Chronological"/>
+            <xs:enumeration value="Demand"/>
+            <xs:enumeration value="Manual"/>
+            <xs:enumeration value="Programmable"/>
+            <xs:enumeration value="Scheduled"/>
+            <xs:enumeration value="Other"/>
+            <xs:enumeration value="Unknown"/>
+            <xs:enumeration value="None"/>
+            <xs:enumeration value=""/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -16642,7 +16642,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyGeneralType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Control strategy for advanced power strip.</xs:documentation>
               </xs:annotation>
@@ -16662,7 +16662,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyGeneralType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Control strategy for manual control.</xs:documentation>
               </xs:annotation>
@@ -16682,35 +16682,15 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlSensor" minOccurs="0">
+            <xs:element name="ControlSensor" type="auc:ControlSensorOccupancyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Type of sensor for detecting occupancy.</xs:documentation>
               </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Passive infrared"/>
-                  <xs:enumeration value="Ultrasonic"/>
-                  <xs:enumeration value="Passive infrared and ultrasonic"/>
-                  <xs:enumeration value="Microwave"/>
-                  <xs:enumeration value="Camera"/>
-                  <xs:enumeration value="Other"/>
-                  <xs:enumeration value="Unknown"/>
-                </xs:restriction>
-              </xs:simpleType>
             </xs:element>
-            <xs:element name="ControlStrategy" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyOccupancyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Occupancy-based control strategy.</xs:documentation>
               </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Occupancy Sensors"/>
-                  <xs:enumeration value="Vacancy Sensors"/>
-                  <xs:enumeration value="Other"/>
-                  <xs:enumeration value="None"/>
-                  <xs:enumeration value="Unknown"/>
-                </xs:restriction>
-              </xs:simpleType>
             </xs:element>
             <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
               <xs:annotation>
@@ -16727,7 +16707,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyGeneralType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Timer-based control strategy for lighting.</xs:documentation>
               </xs:annotation>
@@ -16747,7 +16727,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyGeneralType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Thermostat controller strategy.</xs:documentation>
               </xs:annotation>
@@ -16772,7 +16752,7 @@
                 <xs:documentation>Custom defined name for the type of control technology used.</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyGeneralType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>HVAC control strategy for other control technology.</xs:documentation>
               </xs:annotation>
@@ -16787,7 +16767,7 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <xs:simpleType name="ControlGeneralStrategyType">
+  <xs:simpleType name="ControlStrategyGeneralType">
     <xs:annotation>
       <xs:documentation>Enumerations for general control strategies.</xs:documentation>
     </xs:annotation>
@@ -16815,7 +16795,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyLightingType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Controller strategy.</xs:documentation>
               </xs:annotation>
@@ -16835,18 +16815,10 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlSensor" minOccurs="0">
+            <xs:element name="ControlSensor" type="auc:ControlSensorDaylightingType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Type of sensor for daylighting.</xs:documentation>
               </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Camera"/>
-                  <xs:enumeration value="Photocell"/>
-                  <xs:enumeration value="Other"/>
-                  <xs:enumeration value="Unknown"/>
-                </xs:restriction>
-              </xs:simpleType>
             </xs:element>
             <xs:element name="ControlSteps" minOccurs="0">
               <xs:annotation>
@@ -16860,21 +16832,10 @@
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
-            <xs:element name="ControlStrategy" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Daylighting control strategy.</xs:documentation>
               </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Continuous"/>
-                  <xs:enumeration value="Continuous Plus Off"/>
-                  <xs:enumeration value="Stepped Dimming"/>
-                  <xs:enumeration value="Stepped Switching"/>
-                  <xs:enumeration value="Other"/>
-                  <xs:enumeration value="None"/>
-                  <xs:enumeration value="Unknown"/>
-                </xs:restriction>
-              </xs:simpleType>
             </xs:element>
             <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
               <xs:annotation>
@@ -16940,19 +16901,10 @@
                 </xs:restriction>
               </xs:simpleType>
             </xs:element>
-            <xs:element name="ControlStrategy" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyOccupancyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Occupancy-based control strategy.</xs:documentation>
               </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Occupancy Sensors"/>
-                  <xs:enumeration value="Vacancy Sensors"/>
-                  <xs:enumeration value="Other"/>
-                  <xs:enumeration value="None"/>
-                  <xs:enumeration value="Unknown"/>
-                </xs:restriction>
-              </xs:simpleType>
             </xs:element>
             <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
               <xs:annotation>
@@ -16969,7 +16921,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyLightingType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Timer-based control strategy for lighting.</xs:documentation>
               </xs:annotation>
@@ -16991,7 +16943,7 @@
                 <xs:documentation>Name of the other control technology used.</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyLightingType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Control strategy used for other control technology.</xs:documentation>
               </xs:annotation>
@@ -17006,25 +16958,6 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <xs:simpleType name="ControlLightingStrategyType">
-    <xs:annotation>
-      <xs:documentation>Enumerations for lighting control strategies.</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="Advanced"/>
-      <xs:enumeration value="Always On"/>
-      <xs:enumeration value="Astronomical"/>
-      <xs:enumeration value="Chronological"/>
-      <xs:enumeration value="Demand"/>
-      <xs:enumeration value="EMCS"/>
-      <xs:enumeration value="Manual"/>
-      <xs:enumeration value="Programmable"/>
-      <xs:enumeration value="Timer"/>
-      <xs:enumeration value="Other"/>
-      <xs:enumeration value="Unknown"/>
-      <xs:enumeration value="None"/>
-    </xs:restriction>
-  </xs:simpleType>
   <xs:element name="ControlSystemType">
     <xs:annotation>
       <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
@@ -17037,21 +16970,10 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
-                  <xs:restriction base="xs:string">
-                    <xs:enumeration value="AMX192"/>
-                    <xs:enumeration value="Current"/>
-                    <xs:enumeration value="D54"/>
-                    <xs:enumeration value="Voltage"/>
-                    <xs:enumeration value="Other"/>
-                    <xs:enumeration value="Unknown"/>
-                    <xs:enumeration value="None"/>
-                  </xs:restriction>
-                </xs:simpleType>
               </xs:element>
             </xs:sequence>
           </xs:complexType>
@@ -17062,29 +16984,10 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
-                  <xs:restriction base="xs:string">
-                    <xs:enumeration value="BACnet"/>
-                    <xs:enumeration value="DALI"/>
-                    <xs:enumeration value="DMX512"/>
-                    <xs:enumeration value="DSI "/>
-                    <xs:enumeration value="EnOcean"/>
-                    <xs:enumeration value="KMX"/>
-                    <xs:enumeration value="Konnex"/>
-                    <xs:enumeration value="LonTalk"/>
-                    <xs:enumeration value="MODBUS"/>
-                    <xs:enumeration value="PROFIBUS FMS"/>
-                    <xs:enumeration value="X10"/>
-                    <xs:enumeration value="ZigBee"/>
-                    <xs:enumeration value="Other"/>
-                    <xs:enumeration value="Unknown"/>
-                    <xs:enumeration value="None"/>
-                  </xs:restriction>
-                </xs:simpleType>
               </xs:element>
             </xs:sequence>
           </xs:complexType>
@@ -17116,4 +17019,92 @@
       <xs:documentation>Does the building include a building automation or management system?</xs:documentation>
     </xs:annotation>
   </xs:element>
+  <xs:simpleType name="ControlStrategyLightingType">
+    <xs:annotation>
+      <xs:documentation>Enumerations for lighting control strategies.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Advanced"/>
+      <xs:enumeration value="Always On"/>
+      <xs:enumeration value="Astronomical"/>
+      <xs:enumeration value="Chronological"/>
+      <xs:enumeration value="Demand"/>
+      <xs:enumeration value="EMCS"/>
+      <xs:enumeration value="Manual"/>
+      <xs:enumeration value="Programmable"/>
+      <xs:enumeration value="Timer"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="Unknown"/>
+      <xs:enumeration value="None"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ControlSensorOccupancyType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Passive infrared"/>
+      <xs:enumeration value="Ultrasonic"/>
+      <xs:enumeration value="Passive infrared and ultrasonic"/>
+      <xs:enumeration value="Microwave"/>
+      <xs:enumeration value="Camera"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="Unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ControlSensorDaylightingType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Camera"/>
+      <xs:enumeration value="Photocell"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="Unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ControlStrategyDaylightingType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Continuous"/>
+      <xs:enumeration value="Continuous Plus Off"/>
+      <xs:enumeration value="Stepped Dimming"/>
+      <xs:enumeration value="Stepped Switching"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="None"/>
+      <xs:enumeration value="Unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ControlStrategyOccupancyType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Occupancy Sensors"/>
+      <xs:enumeration value="Vacancy Sensors"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="None"/>
+      <xs:enumeration value="Unknown"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CommunicationProtocolAnalogType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="AMX192"/>
+      <xs:enumeration value="Current"/>
+      <xs:enumeration value="D54"/>
+      <xs:enumeration value="Voltage"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="Unknown"/>
+      <xs:enumeration value="None"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CommunicationProtocolDigitalType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="BACnet"/>
+      <xs:enumeration value="DALI"/>
+      <xs:enumeration value="DMX512"/>
+      <xs:enumeration value="DSI "/>
+      <xs:enumeration value="EnOcean"/>
+      <xs:enumeration value="KMX"/>
+      <xs:enumeration value="Konnex"/>
+      <xs:enumeration value="LonTalk"/>
+      <xs:enumeration value="MODBUS"/>
+      <xs:enumeration value="PROFIBUS FMS"/>
+      <xs:enumeration value="X10"/>
+      <xs:enumeration value="ZigBee"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="Unknown"/>
+      <xs:enumeration value="None"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -9661,7 +9661,7 @@
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="Daylighting" minOccurs="0">
+                              <xs:element name="Photocell" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Type of daylighting controls used to manage lighting.</xs:documentation>
                                 </xs:annotation>
@@ -9670,6 +9670,7 @@
                                     <xs:element name="ControlStrategy">
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
+                                          <xs:enumeration value="On/Off"/>
                                           <xs:enumeration value="Continuous"/>
                                           <xs:enumeration value="Continuous Plus Off"/>
                                           <xs:enumeration value="Stepped Dimming"/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:annotation>
     <xs:documentation>BuildingSync Schema - Version 2.0-prerelease</xs:documentation>
@@ -6414,7 +6415,13 @@
                           </xs:annotation>
                         </xs:element>
                         <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
-                        <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+                        <xs:element name="Controls" minOccurs="0">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="Control" type="auc:ControlHVACType" minOccurs="0" maxOccurs="unbounded"/>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
                         <xs:element ref="auc:Location" minOccurs="0"/>
                         <xs:element ref="auc:YearInstalled" minOccurs="0"/>
                         <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -8581,6 +8588,17 @@
       <xs:element ref="auc:PrimaryFuel" minOccurs="0"/>
       <xs:element name="OtherHVACSystemCondition" type="auc:EquipmentCondition" minOccurs="0"/>
       <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlHVACType" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>HVAC Control Technologies</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:Manufacturer" minOccurs="0"/>
       <xs:element ref="auc:ModelNumber" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -8889,66 +8907,6 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="LightingControlTypeOccupancy" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Type of occupancy controls used to manage lighting. - Will move to LightingControl</xs:documentation>
-        </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Occupancy Sensors"/>
-            <xs:enumeration value="Vacancy Sensors"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="None"/>
-            <xs:enumeration value="Unknown"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="LightingControlTypeTimer" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Type of timer controls used to manage lighting.  - Will move to lighting control.</xs:documentation>
-        </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Astronomical"/>
-            <xs:enumeration value="Chronological"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="None"/>
-            <xs:enumeration value="Unknown"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="LightingControlTypeDaylighting" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Type of daylighting controls used to manage lighting. - Will move to lighting control</xs:documentation>
-        </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Continuous"/>
-            <xs:enumeration value="Continuous Plus Off"/>
-            <xs:enumeration value="Stepped Dimming"/>
-            <xs:enumeration value="Stepped Switching"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="None"/>
-            <xs:enumeration value="Unknown"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="LightingControlTypeManual" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Type of manual controls used to manage lighting. -Will move to lighting control.</xs:documentation>
-        </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Manual On/Off"/>
-            <xs:enumeration value="Manual Dimming"/>
-            <xs:enumeration value="Bi-level Control"/>
-            <xs:enumeration value="Tri-level Control"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="None"/>
-            <xs:enumeration value="Unknown"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
       <xs:element name="DimmingCapability" minOccurs="0">
         <xs:annotation>
           <xs:documentation>If exists then the lighting system can be dimmed across a range of outputs.</xs:documentation>
@@ -9145,682 +9103,20 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="Controls_1" minOccurs="0">
+      <xs:element name="Controls" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>List of controls for system.</xs:documentation>
+          <xs:documentation>List of system operation controls.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="Control" type="auc:ControlOptionType" maxOccurs="unbounded">
+            <xs:element name="Control" type="auc:ControlLightingType" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation>
-                <xs:documentation>Type of control.</xs:documentation>
+                <xs:documentation>Type of system operation control.</xs:documentation>
               </xs:annotation>
             </xs:element>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="Controls_2">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="HVACControl" minOccurs="0" maxOccurs="unbounded">
-              <xs:annotation>
-                <xs:documentation>Type of control.</xs:documentation>
-              </xs:annotation>
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="Pneumatic" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="ControlTechnology" minOccurs="0">
-                          <xs:complexType>
-                            <xs:sequence>
-                              <xs:element name="Thermostat" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Other" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                            </xs:sequence>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="Analog" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="CommunicationProtocol" minOccurs="0">
-                          <xs:annotation>
-                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
-                          </xs:annotation>
-                          <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                              <xs:enumeration value="0-10V"/>
-                              <xs:enumeration value="4-20mA"/>
-                            </xs:restriction>
-                          </xs:simpleType>
-                        </xs:element>
-                        <xs:element name="ControlTechnology" minOccurs="0">
-                          <xs:complexType>
-                            <xs:sequence>
-                              <xs:element name="Thermostat" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Timer" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Astronomical"/>
-                                          <xs:enumeration value="Chronological"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Other" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                            </xs:sequence>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="DirectDigitalControl" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="CommunicationProtocol" minOccurs="0">
-                          <xs:annotation>
-                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
-                          </xs:annotation>
-                          <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                              <xs:enumeration value="BACnet"/>
-                              <xs:enumeration value="Konnex"/>
-                              <xs:enumeration value="LonTalk"/>
-                              <xs:enumeration value="MODBUS"/>
-                              <xs:enumeration value="PROFIBUS FMS"/>
-                              <xs:enumeration value="ZibBee"/>
-                              <xs:enumeration value="Unknown"/>
-                              <xs:enumeration value="Other"/>
-                            </xs:restriction>
-                          </xs:simpleType>
-                        </xs:element>
-                        <xs:element name="ControlTechnology" minOccurs="0">
-                          <xs:complexType>
-                            <xs:sequence>
-                              <xs:element name="ECMS" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Thermostat" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Timer" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Chronological"/>
-                                          <xs:enumeration value="Astronomical"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Other" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                            </xs:sequence>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="Other" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="OtherControlType" type="xs:string" minOccurs="0"/>
-                        <xs:element name="ControlTechnology" minOccurs="0">
-                          <xs:complexType>
-                            <xs:sequence>
-                              <xs:element name="AdvancedPowerStrip" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="ECMS" minOccurs="0"/>
-                              <xs:element name="None" minOccurs="0"/>
-                            </xs:sequence>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="LightingControl" minOccurs="0" maxOccurs="unbounded">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="Analog" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="CommunicationProtocol" minOccurs="0">
-                          <xs:annotation>
-                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
-                          </xs:annotation>
-                          <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                              <xs:enumeration value="0-10V"/>
-                              <xs:enumeration value="AMX192"/>
-                              <xs:enumeration value="D54"/>
-                              <xs:enumeration value="Other"/>
-                              <xs:enumeration value="Unknown"/>
-                              <xs:enumeration value="None"/>
-                            </xs:restriction>
-                          </xs:simpleType>
-                        </xs:element>
-                        <xs:element name="ControlTechnology" minOccurs="0">
-                          <xs:complexType>
-                            <xs:sequence>
-                              <xs:element name="Daylighting" minOccurs="0">
-                                <xs:annotation>
-                                  <xs:documentation>Type of daylighting controls used to manage lighting.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Continuous"/>
-                                          <xs:enumeration value="Continuous Plus Off"/>
-                                          <xs:enumeration value="Stepped Dimming"/>
-                                          <xs:enumeration value="Stepped Switching"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                    <xs:element name="ControlSteps" minOccurs="0">
-                                      <xs:annotation>
-                                        <xs:documentation>For stepped dimming, the number of equally spaced control steps.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:complexType>
-                                        <xs:simpleContent>
-                                          <xs:extension base="xs:integer">
-                                            <xs:attribute ref="auc:Source"/>
-                                          </xs:extension>
-                                        </xs:simpleContent>
-                                      </xs:complexType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Manual" minOccurs="0">
-                                <xs:annotation>
-                                  <xs:documentation>Type of manual controls used to manage lighting.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStategy">
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Manual On/Off"/>
-                                          <xs:enumeration value="Manual Dimming"/>
-                                          <xs:enumeration value="Bi-level Control"/>
-                                          <xs:enumeration value="Tri-level Control"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Occupancy" minOccurs="0">
-                                <xs:annotation>
-                                  <xs:documentation>Type of occupancy controls used to manage lighting.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Occupancy Sensors"/>
-                                          <xs:enumeration value="Vacancy Sensors"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Other" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Advanced"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                            </xs:sequence>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="Digital" minOccurs="0">
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="CommunicationProtocol" minOccurs="0">
-                          <xs:annotation>
-                            <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
-                          </xs:annotation>
-                          <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                              <xs:enumeration value="BACnet"/>
-                              <xs:enumeration value="Konnex"/>
-                              <xs:enumeration value="LonTalk"/>
-                              <xs:enumeration value="MODBUS"/>
-                              <xs:enumeration value="PROFIBUS FMS"/>
-                              <xs:enumeration value="ZibBee"/>
-                              <xs:enumeration value="Unknown"/>
-                              <xs:enumeration value="Other"/>
-                              <xs:enumeration value="DALI"/>
-                              <xs:enumeration value="DSI "/>
-                              <xs:enumeration value="DMX512"/>
-                              <xs:enumeration value="KMX"/>
-                              <xs:enumeration value="EnOcean"/>
-                              <xs:enumeration value="X10"/>
-                            </xs:restriction>
-                          </xs:simpleType>
-                        </xs:element>
-                        <xs:element name="ControlTechnology" minOccurs="0">
-                          <xs:complexType>
-                            <xs:sequence>
-                              <xs:element name="AdvancedPowerStrip" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Photocell" minOccurs="0">
-                                <xs:annotation>
-                                  <xs:documentation>Type of daylighting controls used to manage lighting.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="On/Off"/>
-                                          <xs:enumeration value="Continuous"/>
-                                          <xs:enumeration value="Continuous Plus Off"/>
-                                          <xs:enumeration value="Stepped Dimming"/>
-                                          <xs:enumeration value="Stepped Switching"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                    <xs:element name="ControlSteps" minOccurs="0">
-                                      <xs:annotation>
-                                        <xs:documentation>For stepped dimming, the number of equally spaced control steps.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:complexType>
-                                        <xs:simpleContent>
-                                          <xs:extension base="xs:integer">
-                                            <xs:attribute ref="auc:Source"/>
-                                          </xs:extension>
-                                        </xs:simpleContent>
-                                      </xs:complexType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="ECMS" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Always On"/>
-                                          <xs:enumeration value="Aquastat"/>
-                                          <xs:enumeration value="Demand"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Manual" minOccurs="0">
-                                <xs:annotation>
-                                  <xs:documentation>Type of manual controls used to manage lighting.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStategy">
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Manual On/Off"/>
-                                          <xs:enumeration value="Manual Dimming"/>
-                                          <xs:enumeration value="Bi-level Control"/>
-                                          <xs:enumeration value="Tri-level Control"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Occupancy" minOccurs="0">
-                                <xs:annotation>
-                                  <xs:documentation>Type of occupancy controls used to manage lighting.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Occupancy Sensors"/>
-                                          <xs:enumeration value="Vacancy Sensors"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Timer" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Chronological"/>
-                                          <xs:enumeration value="Astronomical"/>
-                                          <xs:enumeration value="Manual"/>
-                                          <xs:enumeration value="Programmable"/>
-                                          <xs:enumeration value="Scheduled"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="None"/>
-                                          <xs:enumeration value="Unknown"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                              <xs:element name="Other" minOccurs="0">
-                                <xs:complexType>
-                                  <xs:sequence>
-                                    <xs:element name="ControlStrategy">
-                                      <xs:annotation>
-                                        <xs:documentation>Controller strategy.</xs:documentation>
-                                      </xs:annotation>
-                                      <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                          <xs:enumeration value="Advanced"/>
-                                          <xs:enumeration value="Other"/>
-                                          <xs:enumeration value="Unknown"/>
-                                          <xs:enumeration value="None"/>
-                                        </xs:restriction>
-                                      </xs:simpleType>
-                                    </xs:element>
-                                  </xs:sequence>
-                                </xs:complexType>
-                              </xs:element>
-                            </xs:sequence>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="Other" minOccurs="0" maxOccurs="unbounded"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:PrimaryFuel" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
@@ -17094,79 +16390,389 @@
       <xs:documentation>Year that the burner was installed</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:complexType name="ControlOptionType">
+  <xs:complexType name="ControlTypes">
+    <xs:choice>
+      <xs:element name="Analog">
+        <xs:annotation>
+          <xs:documentation>Analog control system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CommunicationProtocol" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="AMX192"/>
+                  <xs:enumeration value="Current"/>
+                  <xs:enumeration value="D54"/>
+                  <xs:enumeration value="Voltage"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="Unknown"/>
+                  <xs:enumeration value="None"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Digital">
+        <xs:annotation>
+          <xs:documentation>Digital (or Direct Digital Control [DDC]) system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CommunicationProtocol" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="BACnet"/>
+                  <xs:enumeration value="DALI"/>
+                  <xs:enumeration value="DMX512"/>
+                  <xs:enumeration value="DSI "/>
+                  <xs:enumeration value="EnOcean"/>
+                  <xs:enumeration value="KMX"/>
+                  <xs:enumeration value="Konnex"/>
+                  <xs:enumeration value="LonTalk"/>
+                  <xs:enumeration value="MODBUS"/>
+                  <xs:enumeration value="PROFIBUS FMS"/>
+                  <xs:enumeration value="X10"/>
+                  <xs:enumeration value="ZigBee"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="Unknown"/>
+                  <xs:enumeration value="None"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Pneumatic">
+        <xs:annotation>
+          <xs:documentation>Pneumatic-based controls.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Other">
+        <xs:annotation>
+          <xs:documentation>Other type of control system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="OtherCommunicationProtocolName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Name of the other communication protocal that is being used to communicate data over a computer network.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:choice>
+  </xs:complexType>
+  <xs:complexType name="ControlHVACType">
+    <xs:annotation>
+      <xs:documentation>An instance of an HVAC control technology.</xs:documentation>
+    </xs:annotation>
     <xs:sequence>
-      <xs:element name="ControllerType" minOccurs="0">
+      <xs:element name="AdvancedPowerStrip" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>The type of controller. E.g., electronic, pneumatic.</xs:documentation>
+          <xs:documentation>HVAC control by means of advanced power strip.</xs:documentation>
         </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Analog"/>
-            <xs:enumeration value="Direct digital control"/>
-            <xs:enumeration value="Pneumatic"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="Unknown"/>
-          </xs:restriction>
-        </xs:simpleType>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Control strategy for advanced power strip.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
       </xs:element>
-      <xs:element name="CommunicationProtocol" minOccurs="0">
+      <xs:element name="Manual" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Method of communicating data over a computer network.</xs:documentation>
+          <xs:documentation>Manual operation of HVAC system.</xs:documentation>
         </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="0-10V"/>
-            <xs:enumeration value="BACnet"/>
-            <xs:enumeration value="Konnex"/>
-            <xs:enumeration value="LonTalk"/>
-            <xs:enumeration value="MODBUS"/>
-            <xs:enumeration value="PROFIBUS FMS"/>
-            <xs:enumeration value="ZibBee"/>
-            <xs:enumeration value="Unknown"/>
-            <xs:enumeration value="Other"/>
-          </xs:restriction>
-        </xs:simpleType>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Control strategy for manual control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
       </xs:element>
-      <xs:element name="ControlTechnology" minOccurs="0">
+      <xs:element name="Thermostat" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Technological device that enables control of the system.</xs:documentation>
+          <xs:documentation>Thermostat-based control technology.</xs:documentation>
         </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Advanced power strip"/>
-            <xs:enumeration value="EMCS"/>
-            <xs:enumeration value="Thermostat"/>
-            <xs:enumeration value="Thermostatic radiator valve"/>
-            <xs:enumeration value="Thermostatic zone valve"/>
-            <xs:enumeration value="Timer"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="Unknown"/>
-            <xs:enumeration value="None"/>
-          </xs:restriction>
-        </xs:simpleType>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Thermostat controller strategy.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
       </xs:element>
-      <xs:element name="ControlStrategy" minOccurs="0">
+      <xs:element name="OtherControlTechnology" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>The strategy used to control the system.</xs:documentation>
+          <xs:documentation>Other control technology.</xs:documentation>
         </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Always On"/>
-            <xs:enumeration value="Astronomical"/>
-            <xs:enumeration value="Aquastat"/>
-            <xs:enumeration value="Chronological"/>
-            <xs:enumeration value="Demand"/>
-            <xs:enumeration value="Manual"/>
-            <xs:enumeration value="Programmable"/>
-            <xs:enumeration value="Scheduled"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="Unknown"/>
-            <xs:enumeration value="None"/>
-            <xs:enumeration value=""/>
-          </xs:restriction>
-        </xs:simpleType>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlTechnologyName" type="xs:string" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>HVAC control strategy for other control technology.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+  <xs:simpleType name="ControlHVACStrategyType">
+    <xs:annotation>
+      <xs:documentation>Enumerations for HVAC control strategies.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Always On"/>
+      <xs:enumeration value="Aquastat"/>
+      <xs:enumeration value="Astronomical"/>
+      <xs:enumeration value="Chronological"/>
+      <xs:enumeration value="EMCS"/>
+      <xs:enumeration value="Demand"/>
+      <xs:enumeration value="Manual"/>
+      <xs:enumeration value="Programmable"/>
+      <xs:enumeration value="Timer"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="Unknown"/>
+      <xs:enumeration value="None"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ControlLightingType">
+    <xs:annotation>
+      <xs:documentation>An instance of a lighting control technology.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="AdvancedPowerStrip" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Controller strategy.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Daylighting" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Type of daylighting controls used to manage lighting.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element name="ControlSensor" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Type of sensor for daylighting.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Camera"/>
+                  <xs:enumeration value="Photocell"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+            <xs:element name="ControlSteps" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>For stepped dimming, the number of equally spaced control steps.</xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:simpleContent>
+                  <xs:extension base="xs:integer">
+                    <xs:attribute ref="auc:Source"/>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Daylighting control strategy.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Manual" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Type of manual controls used to manage lighting.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Manual lighting control strategy.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Occupancy" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Type of occupancy controls used to manage lighting. </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element name="ControlSensor" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Type of sensor for detecting occupancy.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Passive infrared"/>
+                  <xs:enumeration value="Ultrasonic"/>
+                  <xs:enumeration value="Passive infrared and ultrasonic"/>
+                  <xs:enumeration value="Microwave"/>
+                  <xs:enumeration value="Camera"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Occupancy-based control strategy.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Timer" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Type of timer-based controls for managing lighting on specified timed intervals.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Timer-based control strategy for lighting.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="OtherControlTechnology" minOccurs="0">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element name="OtherControlTechnologyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Name of the other control technology used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Control strategy used for other control technology.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="ControlLightingStrategyType">
+    <xs:annotation>
+      <xs:documentation>Enumerations for lighting control strategies.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Advanced"/>
+      <xs:enumeration value="Always On"/>
+      <xs:enumeration value="Astronomical"/>
+      <xs:enumeration value="Chronological"/>
+      <xs:enumeration value="Demand"/>
+      <xs:enumeration value="Manual"/>
+      <xs:enumeration value="Programmable"/>
+      <xs:enumeration value="Timer"/>
+      <xs:enumeration value="Other"/>
+      <xs:enumeration value="Unknown"/>
+      <xs:enumeration value="None"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -927,11 +927,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="BuildingAutomationSystem" type="xs:boolean" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Does the building include a building automation or management system?</xs:documentation>
-        </xs:annotation>
-      </xs:element>
+      <xs:element ref="auc:BuildingAutomationSystem" minOccurs="0"/>
       <xs:element name="HistoricalLandmark" type="xs:boolean" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Does the facility have historical landmark status (e.g. is the facility listed in the National Register of Historic Places)?</xs:documentation>
@@ -6416,9 +6412,16 @@
                         </xs:element>
                         <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>List of controls for heating source.</xs:documentation>
+                          </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlHVACType" minOccurs="0" maxOccurs="unbounded"/>
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                                <xs:annotation>
+                                  <xs:documentation>Control for heating source.</xs:documentation>
+                                </xs:annotation>
+                              </xs:element>
                             </xs:sequence>
                           </xs:complexType>
                         </xs:element>
@@ -6641,7 +6644,20 @@
                           </xs:annotation>
                         </xs:element>
                         <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
-                        <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+                        <xs:element name="Controls" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>List of controls for cooling source.</xs:documentation>
+                          </xs:annotation>
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                                <xs:annotation>
+                                  <xs:documentation>Cooling source control.</xs:documentation>
+                                </xs:annotation>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
                         <xs:element ref="auc:Location" minOccurs="0"/>
                         <xs:element ref="auc:YearInstalled" minOccurs="0"/>
                         <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -6862,7 +6878,20 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+                        <xs:element name="Controls" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>List of controls for delivery system.</xs:documentation>
+                          </xs:annotation>
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                                <xs:annotation>
+                                  <xs:documentation>Delivery system control.</xs:documentation>
+                                </xs:annotation>
+                              </xs:element>
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
                         <xs:element ref="auc:YearInstalled" minOccurs="0"/>
                         <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
                         <xs:element ref="auc:Manufacturer" minOccurs="0"/>
@@ -6942,19 +6971,15 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="PrimaryHVACControls" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>The main types of HVAC controls that are used for this system.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="PrimaryHVACControlStrategy" minOccurs="0">
+      <xs:element name="PrimaryHVACControlSystemType" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Primary HVAC equipment control strategy.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
+            <xs:enumeration value="Analog"/>
+            <xs:enumeration value="Digital"/>
             <xs:enumeration value="Pneumatic"/>
-            <xs:enumeration value="Electronic"/>
             <xs:enumeration value="Other"/>
             <xs:enumeration value="Unknown"/>
           </xs:restriction>
@@ -7625,6 +7650,12 @@
           <xs:documentation>Main fuel used by the heating plant.</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element ref="auc:BuildingAutomationSystem" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Does the building/system include or connect to a building automation or management system?</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="ID" type="xs:ID"/>
@@ -7914,6 +7945,12 @@
           <xs:documentation>Main fuel used by the cooling plant.</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element ref="auc:BuildingAutomationSystem" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Does the building/system include a building automation or management system?</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="ID" type="xs:ID"/>
@@ -8272,6 +8309,12 @@
           <xs:documentation>Main fuel used by the condenser plant.</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element ref="auc:BuildingAutomationSystem" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Does the building/system include a building automation or management system?</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="ID" type="xs:ID"/>
@@ -8587,13 +8630,15 @@
       <xs:element ref="auc:Location" minOccurs="0"/>
       <xs:element ref="auc:PrimaryFuel" minOccurs="0"/>
       <xs:element name="OtherHVACSystemCondition" type="auc:EquipmentCondition" minOccurs="0"/>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
       <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for other HVAC systems.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="Control" type="auc:ControlHVACType" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
               <xs:annotation>
-                <xs:documentation>HVAC Control Technologies</xs:documentation>
+                <xs:documentation>Other HVAC system control.</xs:documentation>
               </xs:annotation>
             </xs:element>
           </xs:sequence>
@@ -9109,7 +9154,7 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="Control" type="auc:ControlLightingType" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Control" type="auc:ControlLightingType" maxOccurs="unbounded">
               <xs:annotation>
                 <xs:documentation>Type of system operation control.</xs:documentation>
               </xs:annotation>
@@ -9316,7 +9361,20 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+                                          <xs:element name="Controls" minOccurs="0">
+                                            <xs:annotation>
+                                              <xs:documentation>List of controls for solar hot water.</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                              <xs:sequence>
+                                                <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                                                  <xs:annotation>
+                                                    <xs:documentation>Solar hot water control.</xs:documentation>
+                                                  </xs:annotation>
+                                                </xs:element>
+                                              </xs:sequence>
+                                            </xs:complexType>
+                                          </xs:element>
                                           <xs:element ref="auc:Quantity" minOccurs="0"/>
                                           <xs:element ref="auc:YearInstalled" minOccurs="0"/>
                                           <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -9631,7 +9689,20 @@
       <xs:element ref="auc:Capacity" minOccurs="0"/>
       <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for domestic hot water.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Domestic hot water control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
       <xs:element ref="auc:PrimaryFuel" minOccurs="0"/>
@@ -10146,7 +10217,20 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for dishwasher.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Dishwasher control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -10355,7 +10439,20 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for laundry system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Laundry system control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -10501,7 +10598,20 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for pump system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Pump system control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:Quantity" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
@@ -10715,7 +10825,20 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for fan system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Fan system control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:Quantity" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
@@ -10859,7 +10982,20 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for motor systems.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Motor system control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:Quantity" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
@@ -10948,7 +11084,20 @@
           <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for heat recovery system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Heat recovery system control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:Quantity" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
@@ -12765,7 +12914,20 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for critical IT system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Critical IT system control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -12853,7 +13015,20 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of plug load controls.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Plug load control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -12941,7 +13116,20 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:DutyCycle" minOccurs="0"/>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of process load controls.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Process load control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -13012,7 +13200,20 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of conveyance system controls.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Conveyance system control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:Quantity" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
@@ -13294,7 +13495,20 @@
       </xs:element>
       <xs:element ref="auc:Capacity" minOccurs="0"/>
       <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of onsite storage transmission controls.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Onsite storage transmission control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
@@ -13404,7 +13618,20 @@
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
-            <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+            <xs:element name="Controls" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>List of controls for heated pool.</xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                    <xs:annotation>
+                      <xs:documentation>Heated pool control.</xs:documentation>
+                    </xs:annotation>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -13508,7 +13735,20 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
-      <xs:element ref="auc:ControlTechnology" minOccurs="0"/>
+      <xs:element name="Controls" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>List of controls for water use system.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>Control for water use.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
       <xs:element ref="auc:YearInstalled" minOccurs="0"/>
       <xs:element ref="auc:YearofManufacture" minOccurs="0"/>
       <xs:element ref="auc:Manufacturer" minOccurs="0"/>
@@ -16390,104 +16630,19 @@
       <xs:documentation>Year that the burner was installed</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:complexType name="ControlTypes">
-    <xs:choice>
-      <xs:element name="Analog">
-        <xs:annotation>
-          <xs:documentation>Analog control system.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="CommunicationProtocol" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
-              </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="AMX192"/>
-                  <xs:enumeration value="Current"/>
-                  <xs:enumeration value="D54"/>
-                  <xs:enumeration value="Voltage"/>
-                  <xs:enumeration value="Other"/>
-                  <xs:enumeration value="Unknown"/>
-                  <xs:enumeration value="None"/>
-                </xs:restriction>
-              </xs:simpleType>
-            </xs:element>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="Digital">
-        <xs:annotation>
-          <xs:documentation>Digital (or Direct Digital Control [DDC]) system.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="CommunicationProtocol" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
-              </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="BACnet"/>
-                  <xs:enumeration value="DALI"/>
-                  <xs:enumeration value="DMX512"/>
-                  <xs:enumeration value="DSI "/>
-                  <xs:enumeration value="EnOcean"/>
-                  <xs:enumeration value="KMX"/>
-                  <xs:enumeration value="Konnex"/>
-                  <xs:enumeration value="LonTalk"/>
-                  <xs:enumeration value="MODBUS"/>
-                  <xs:enumeration value="PROFIBUS FMS"/>
-                  <xs:enumeration value="X10"/>
-                  <xs:enumeration value="ZigBee"/>
-                  <xs:enumeration value="Other"/>
-                  <xs:enumeration value="Unknown"/>
-                  <xs:enumeration value="None"/>
-                </xs:restriction>
-              </xs:simpleType>
-            </xs:element>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="Pneumatic">
-        <xs:annotation>
-          <xs:documentation>Pneumatic-based controls.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="Other">
-        <xs:annotation>
-          <xs:documentation>Other type of control system.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="OtherCommunicationProtocolName" type="xs:string" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation>Name of the other communication protocal that is being used to communicate data over a computer network.</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-    </xs:choice>
-  </xs:complexType>
-  <xs:complexType name="ControlHVACType">
+  <xs:complexType name="ControlGeneralType">
     <xs:annotation>
-      <xs:documentation>An instance of an HVAC control technology.</xs:documentation>
+      <xs:documentation>An instance of a general control technology.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:element name="AdvancedPowerStrip" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>HVAC control by means of advanced power strip.</xs:documentation>
+          <xs:documentation>Control by means of advanced power strip.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Control strategy for advanced power strip.</xs:documentation>
               </xs:annotation>
@@ -16502,14 +16657,79 @@
       </xs:element>
       <xs:element name="Manual" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Manual operation of HVAC system.</xs:documentation>
+          <xs:documentation>Manual operation of system.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Control strategy for manual control.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Occupancy" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Occupancy-based controls.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
+            <xs:element name="ControlSensor" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Type of sensor for detecting occupancy.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Passive infrared"/>
+                  <xs:enumeration value="Ultrasonic"/>
+                  <xs:enumeration value="Passive infrared and ultrasonic"/>
+                  <xs:enumeration value="Microwave"/>
+                  <xs:enumeration value="Camera"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+            <xs:element name="ControlStrategy" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Occupancy-based control strategy.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Occupancy Sensors"/>
+                  <xs:enumeration value="Vacancy Sensors"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="None"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+            <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>If ControlStrategy is other, then the name of the strategy used.</xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Timer" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Timer-based controls for specified timed intervals.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>Timer-based control strategy for lighting.</xs:documentation>
               </xs:annotation>
             </xs:element>
             <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
@@ -16526,12 +16746,8 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0">
-              <xs:annotation>
-                <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
-              </xs:annotation>
-            </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
+            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Thermostat controller strategy.</xs:documentation>
               </xs:annotation>
@@ -16550,13 +16766,13 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0">
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
+            <xs:element name="OtherControlTechnologyName" type="xs:string" minOccurs="0">
               <xs:annotation>
-                <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
+                <xs:documentation>Custom defined name for the type of control technology used.</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="OtherControlTechnologyName" type="xs:string" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlHVACStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlGeneralStrategyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>HVAC control strategy for other control technology.</xs:documentation>
               </xs:annotation>
@@ -16571,9 +16787,9 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <xs:simpleType name="ControlHVACStrategyType">
+  <xs:simpleType name="ControlGeneralStrategyType">
     <xs:annotation>
-      <xs:documentation>Enumerations for HVAC control strategies.</xs:documentation>
+      <xs:documentation>Enumerations for general control strategies.</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="Always On"/>
@@ -16598,7 +16814,7 @@
       <xs:element name="AdvancedPowerStrip" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
             <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Controller strategy.</xs:documentation>
@@ -16618,7 +16834,7 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
             <xs:element name="ControlSensor" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Type of sensor for daylighting.</xs:documentation>
@@ -16644,10 +16860,21 @@
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Daylighting control strategy.</xs:documentation>
               </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Continuous"/>
+                  <xs:enumeration value="Continuous Plus Off"/>
+                  <xs:enumeration value="Stepped Dimming"/>
+                  <xs:enumeration value="Stepped Switching"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="None"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
             </xs:element>
             <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
               <xs:annotation>
@@ -16663,11 +16890,24 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
-            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
+            <xs:element name="ControlStrategy" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Manual lighting control strategy.</xs:documentation>
               </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Always On"/>
+                  <xs:enumeration value="Always Off"/>
+                  <xs:enumeration value="Manual On/Off"/>
+                  <xs:enumeration value="Manual Dimming"/>
+                  <xs:enumeration value="Bi-level Control"/>
+                  <xs:enumeration value="Tri-level Control"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="None"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
             </xs:element>
             <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
               <xs:annotation>
@@ -16683,7 +16923,7 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
             <xs:element name="ControlSensor" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Type of sensor for detecting occupancy.</xs:documentation>
@@ -16700,10 +16940,19 @@
                 </xs:restriction>
               </xs:simpleType>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
+            <xs:element name="ControlStrategy" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Occupancy-based control strategy.</xs:documentation>
               </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Occupancy Sensors"/>
+                  <xs:enumeration value="Vacancy Sensors"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="None"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
             </xs:element>
             <xs:element name="OtherControlStrategyName" type="xs:string" minOccurs="0">
               <xs:annotation>
@@ -16719,7 +16968,7 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
             <xs:element name="ControlStrategy" type="auc:ControlLightingStrategyType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Timer-based control strategy for lighting.</xs:documentation>
@@ -16736,7 +16985,7 @@
       <xs:element name="OtherControlTechnology" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="ControlType" type="auc:ControlTypes" minOccurs="0"/>
+            <xs:element ref="auc:ControlSystemType" minOccurs="0"/>
             <xs:element name="OtherControlTechnologyName" type="xs:string" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Name of the other control technology used.</xs:documentation>
@@ -16767,6 +17016,7 @@
       <xs:enumeration value="Astronomical"/>
       <xs:enumeration value="Chronological"/>
       <xs:enumeration value="Demand"/>
+      <xs:enumeration value="EMCS"/>
       <xs:enumeration value="Manual"/>
       <xs:enumeration value="Programmable"/>
       <xs:enumeration value="Timer"/>
@@ -16775,4 +17025,95 @@
       <xs:enumeration value="None"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:element name="ControlSystemType">
+    <xs:annotation>
+      <xs:documentation>Identifier for the type of control (e.g., Pneumatic, Analog, Digital).</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice>
+        <xs:element name="Analog">
+          <xs:annotation>
+            <xs:documentation>Analog control system.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CommunicationProtocol" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="AMX192"/>
+                    <xs:enumeration value="Current"/>
+                    <xs:enumeration value="D54"/>
+                    <xs:enumeration value="Voltage"/>
+                    <xs:enumeration value="Other"/>
+                    <xs:enumeration value="Unknown"/>
+                    <xs:enumeration value="None"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Digital">
+          <xs:annotation>
+            <xs:documentation>Digital (or Direct Digital Control [DDC]) system.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CommunicationProtocol" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="BACnet"/>
+                    <xs:enumeration value="DALI"/>
+                    <xs:enumeration value="DMX512"/>
+                    <xs:enumeration value="DSI "/>
+                    <xs:enumeration value="EnOcean"/>
+                    <xs:enumeration value="KMX"/>
+                    <xs:enumeration value="Konnex"/>
+                    <xs:enumeration value="LonTalk"/>
+                    <xs:enumeration value="MODBUS"/>
+                    <xs:enumeration value="PROFIBUS FMS"/>
+                    <xs:enumeration value="X10"/>
+                    <xs:enumeration value="ZigBee"/>
+                    <xs:enumeration value="Other"/>
+                    <xs:enumeration value="Unknown"/>
+                    <xs:enumeration value="None"/>
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Pneumatic">
+          <xs:annotation>
+            <xs:documentation>Pneumatic-based controls.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Other">
+          <xs:annotation>
+            <xs:documentation>Other type of control system.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="OtherCommunicationProtocolName" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>Name of the other communication protocal that is being used to communicate data over a computer network.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BuildingAutomationSystem" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Does the building include a building automation or management system?</xs:documentation>
+    </xs:annotation>
+  </xs:element>
 </xs:schema>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:annotation>
     <xs:documentation>BuildingSync Schema - Version 2.0-prerelease</xs:documentation>

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,12 @@ task :remove_tabs do
       config.default_xml.noblanks
     end
 
+    doc.xpath('//comment()').each do |node|
+      if node.text =~ /XMLSpy/
+        node.remove
+      end
+    end
+
     File.open(file, 'w') { |f| f << doc.to_xml(:indent => 2) }
   end
 end

--- a/examples/ASHRAE 211 Export.xml
+++ b/examples/ASHRAE 211 Export.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>
     <Facility>
@@ -449,7 +450,13 @@
             </LampType>
             <BallastType>Electromagnetic</BallastType>
             <PercentPremisesServed>0.05</PercentPremisesServed>
-            <ControlTechnology>Always On</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Always On</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -458,7 +465,13 @@
             </LampType>
             <BallastType>Standard Electronic</BallastType>
             <PercentPremisesServed>0.1</PercentPremisesServed>
-            <ControlTechnology>Manual On/Off</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Manual On/Off</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -466,10 +479,16 @@
               <LinearFluorescent/>
             </LampType>
             <BallastType>No Ballast</BallastType>
-            <LightingControlTypeOccupancy>Occupancy Sensors</LightingControlTypeOccupancy>
             <PercentPremisesServed>0.25</PercentPremisesServed>
             <OutsideLighting>true</OutsideLighting>
-            <ControlTechnology>Other</ControlTechnology>
+            <Controls>
+              <Control>
+                <Occupancy>
+                  <ControlSensor>Passive infrared</ControlSensor>
+                  <ControlStrategy>Occupancy Sensors</ControlStrategy>
+                </Occupancy>
+              </Control>
+            </Controls>
             <Location>Exterior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -477,9 +496,15 @@
               <LinearFluorescent/>
             </LampType>
             <BallastType>Other</BallastType>
-            <LightingControlTypeDaylighting>Continuous</LightingControlTypeDaylighting>
             <PercentPremisesServed>0.5</PercentPremisesServed>
-            <ControlTechnology>Other</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlStrategy>Continuous</ControlStrategy>
+                </Daylighting>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -488,7 +513,13 @@
             </LampType>
             <BallastType>Electromagnetic</BallastType>
             <PercentPremisesServed>0.75</PercentPremisesServed>
-            <ControlTechnology>Timer</ControlTechnology>
+            <Controls>
+              <Control>
+                <Timer>
+                  <ControlStrategy>Timer</ControlStrategy>
+                </Timer>
+              </Control>
+            </Controls>
             <Location>Other</Location>
           </LightingSystem>
           <LightingSystem>
@@ -497,7 +528,13 @@
             </LampType>
             <BallastType>Standard Electronic</BallastType>
             <PercentPremisesServed>0.9</PercentPremisesServed>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -506,7 +543,13 @@
             </LampType>
             <BallastType>Electromagnetic</BallastType>
             <PercentPremisesServed>1</PercentPremisesServed>
-            <ControlTechnology>Other</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>Other</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -515,7 +558,13 @@
             </LampType>
             <BallastType>Standard Electronic</BallastType>
             <PercentPremisesServed>1</PercentPremisesServed>
-            <ControlTechnology>Other</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>Other</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -524,7 +573,13 @@
             </LampType>
             <BallastType>Other</BallastType>
             <PercentPremisesServed>1</PercentPremisesServed>
-            <ControlTechnology>Always On</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Always On</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
           <LightingSystem>
@@ -533,7 +588,13 @@
             </LampType>
             <BallastType>Other</BallastType>
             <PercentPremisesServed>1</PercentPremisesServed>
-            <ControlTechnology>Always On</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Always On</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Location>Interior</Location>
           </LightingSystem>
         </LightingSystems>

--- a/examples/ASHRAE 211 Export.xml
+++ b/examples/ASHRAE 211 Export.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>
     <Facility>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <!--This example file is meant to cover the majority of the functionality of New York Local Law 87-->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>
@@ -257,7 +258,13 @@
                 <TankVolume>100</TankVolume>
               </StorageTank>
             </DomesticHotWaterType>
-            <ControlTechnology>Manual Analog Thermostat</ControlTechnology>
+            <Controls>
+              <Control>
+                <Thermostat>
+                  <ControlStrategy>Manual</ControlStrategy>
+                </Thermostat>
+              </Control>
+            </Controls>
             <Location>Mechanical Room</Location>
             <LinkedPremises>
               <Building>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <!--This example file is meant to cover the majority of the functionality of New York Local Law 87-->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>

--- a/examples/Reference Building - Primary School.xml
+++ b/examples/Reference Building - Primary School.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>
     <Facility ID="Audit1">

--- a/examples/Reference Building - Primary School.xml
+++ b/examples/Reference Building - Primary School.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by NREL (NREL) -->
 <BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
   <Facilities>
     <Facility ID="Audit1">
@@ -4013,7 +4014,13 @@
                   <HeatingStaging>Variable</HeatingStaging>
                   <PrimaryFuel>Natural gas</PrimaryFuel>
                   <HeatingSourceCondition>Average</HeatingSourceCondition>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </HeatingSource>
               </HeatingSources>
@@ -4038,7 +4045,13 @@
                   <RatedCoolingSensibleHeatRatio>0.69</RatedCoolingSensibleHeatRatio>
                   <PrimaryFuel>Electricity</PrimaryFuel>
                   <CoolingSourceCondition>Good</CoolingSourceCondition>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </CoolingSource>
                 <CoolingSource ID="CoolsourcePod2">
@@ -4060,7 +4073,13 @@
                   <CoolingStageCapacity>0.5</CoolingStageCapacity>
                   <RatedCoolingSensibleHeatRatio>0.69</RatedCoolingSensibleHeatRatio>
                   <PrimaryFuel>Electricity</PrimaryFuel>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </CoolingSource>
                 <CoolingSource ID="CoolsourcePod3">
@@ -4083,7 +4102,13 @@
                   <RatedCoolingSensibleHeatRatio>0.69</RatedCoolingSensibleHeatRatio>
                   <PrimaryFuel>Electricity</PrimaryFuel>
                   <CoolingSourceCondition>Poor</CoolingSourceCondition>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </CoolingSource>
                 <CoolingSource ID="CoolsourceOther">
@@ -4106,7 +4131,13 @@
                   <RatedCoolingSensibleHeatRatio>0.69</RatedCoolingSensibleHeatRatio>
                   <PrimaryFuel>Electricity</PrimaryFuel>
                   <CoolingSourceCondition>Other</CoolingSourceCondition>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Condition Description</FieldName>
@@ -4139,7 +4170,13 @@
                   </DeliveryType>
                   <HeatingSourceID IDref="Heatsource1"/>
                   <CoolingSourceID IDref="CoolsourcePod1"/>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </Delivery>
                 <Delivery ID="DeliveryPod2">
@@ -4164,7 +4201,13 @@
                   </DeliveryType>
                   <HeatingSourceID IDref="Heatsource1"/>
                   <CoolingSourceID IDref="CoolsourcePod2"/>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </Delivery>
                 <Delivery ID="DeliveryPod3">
@@ -4189,7 +4232,13 @@
                   </DeliveryType>
                   <HeatingSourceID IDref="Heatsource1"/>
                   <CoolingSourceID IDref="CoolsourcePod3"/>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </Delivery>
                 <Delivery ID="DeliveryOther">
@@ -4214,7 +4263,13 @@
                   </DeliveryType>
                   <HeatingSourceID IDref="Heatsource1"/>
                   <CoolingSourceID IDref="CoolsourceOther"/>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </Delivery>
               </Deliveries>
@@ -4293,7 +4348,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone1">
@@ -4316,7 +4377,13 @@
                   </MechanicalVentilation>
                 </OtherHVACType>
                 <OtherHVACSystemCondition>Unknown</OtherHVACSystemCondition>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone2">
@@ -4338,7 +4405,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone3">
@@ -4360,7 +4433,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone4">
@@ -4382,7 +4461,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone5">
@@ -4404,7 +4489,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone6">
@@ -4426,7 +4517,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone7">
@@ -4448,7 +4545,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone8">
@@ -4470,7 +4573,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone9">
@@ -4492,7 +4601,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone10">
@@ -4514,7 +4629,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone11">
@@ -4536,7 +4657,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone12">
@@ -4558,7 +4685,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone13">
@@ -4580,7 +4713,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone14">
@@ -4602,7 +4741,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone15">
@@ -4624,7 +4769,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone16">
@@ -4646,7 +4797,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone17">
@@ -4668,7 +4825,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone18">
@@ -4690,7 +4853,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone19">
@@ -4712,7 +4881,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone20">
@@ -4734,7 +4909,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone21">
@@ -4756,7 +4937,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone25">
@@ -4794,7 +4981,13 @@
                   <InputCapacity>55.04</InputCapacity>
                   <CapacityUnits>kW</CapacityUnits>
                   <PrimaryFuel>Natural gas</PrimaryFuel>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </HeatingSource>
               </HeatingSources>
@@ -4818,7 +5011,13 @@
                   <CoolingStageCapacity>0.5</CoolingStageCapacity>
                   <RatedCoolingSensibleHeatRatio>0.7657</RatedCoolingSensibleHeatRatio>
                   <PrimaryFuel>Electricity</PrimaryFuel>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </CoolingSource>
               </CoolingSources>
@@ -4838,7 +5037,13 @@
                   </DeliveryType>
                   <HeatingSourceID IDref="GymHeating"/>
                   <CoolingSourceID IDref="GymCooling"/>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </Delivery>
               </Deliveries>
@@ -4866,7 +5071,13 @@
                     <DemandControlVentilation>false</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone22">
@@ -4904,7 +5115,13 @@
                   <InputCapacity>30.61</InputCapacity>
                   <CapacityUnits>kW</CapacityUnits>
                   <PrimaryFuel>Natural gas</PrimaryFuel>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </HeatingSource>
               </HeatingSources>
@@ -4928,7 +5145,13 @@
                   <CoolingStageCapacity>0.5</CoolingStageCapacity>
                   <RatedCoolingSensibleHeatRatio>0.7979</RatedCoolingSensibleHeatRatio>
                   <PrimaryFuel>Electricity</PrimaryFuel>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </CoolingSource>
               </CoolingSources>
@@ -4948,7 +5171,13 @@
                   </DeliveryType>
                   <HeatingSourceID IDref="KitchenHeating"/>
                   <CoolingSourceID IDref="KitchenCooling"/>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </Delivery>
               </Deliveries>
@@ -4976,7 +5205,13 @@
                     <DemandControlVentilation>false</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone23">
@@ -5016,7 +5251,13 @@
                   <InputCapacity>110.51</InputCapacity>
                   <CapacityUnits>kW</CapacityUnits>
                   <PrimaryFuel>Natural gas</PrimaryFuel>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </HeatingSource>
               </HeatingSources>
@@ -5040,7 +5281,13 @@
                   <CoolingStageCapacity>0.5</CoolingStageCapacity>
                   <RatedCoolingSensibleHeatRatio>0.7373</RatedCoolingSensibleHeatRatio>
                   <PrimaryFuel>Electricity</PrimaryFuel>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </CoolingSource>
               </CoolingSources>
@@ -5060,7 +5307,13 @@
                   </DeliveryType>
                   <HeatingSourceID IDref="CafeteriaHeating"/>
                   <CoolingSourceID IDref="CafeteriaCooling"/>
-                  <ControlTechnology>EMCS</ControlTechnology>
+                  <Controls>
+                    <Control>
+                      <Thermostat>
+                        <ControlStrategy>EMCS</ControlStrategy>
+                      </Thermostat>
+                    </Control>
+                  </Controls>
                   <Quantity>1</Quantity>
                 </Delivery>
               </Deliveries>
@@ -5088,7 +5341,13 @@
                     <DemandControlVentilation>true</DemandControlVentilation>
                   </MechanicalVentilation>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone24">
@@ -5118,7 +5377,13 @@
                     </VentilationControlMethods>
                   </SpotExhaust>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone20">
@@ -5142,7 +5407,13 @@
                     <MakeupAirSourceID>Zone22</MakeupAirSourceID>
                   </SpotExhaust>
                 </OtherHVACType>
-                <ControlTechnology>EMCS</ControlTechnology>
+                <Controls>
+                  <Control>
+                    <Thermostat>
+                      <ControlStrategy>EMCS</ControlStrategy>
+                    </Thermostat>
+                  </Control>
+                </Controls>
                 <LinkedPremises>
                   <ThermalZone>
                     <LinkedThermalZoneID IDref="Zone23">
@@ -5187,16 +5458,25 @@
         </HVACSystems>
         <LightingSystems>
           <LightingSystem ID="ClassLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>1.492</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5248,16 +5528,25 @@
             <Quantity>6</Quantity>
           </LightingSystem>
           <LightingSystem ID="MultiLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>7.188</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5302,11 +5591,16 @@
             <Quantity>5</Quantity>
           </LightingSystem>
           <LightingSystem ID="CorridorPod1">
-            <LightingControlTypeDaylighting>None</LightingControlTypeDaylighting>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>1.033</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5337,16 +5631,25 @@
             <Quantity>3</Quantity>
           </LightingSystem>
           <LightingSystem ID="MultiLighting2">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>4.747</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5363,16 +5666,25 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="ComputerLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>2.441</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5389,11 +5701,16 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="CorridorMain1">
-            <LightingControlTypeDaylighting>None</LightingControlTypeDaylighting>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>2.939</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5410,16 +5727,25 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="LobbyLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>2.393</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5436,11 +5762,16 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="MechanicalLighting1">
-            <LightingControlTypeDaylighting>None</LightingControlTypeDaylighting>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>4.069</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5457,11 +5788,16 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="RestroomLighting1">
-            <LightingControlTypeDaylighting>None</LightingControlTypeDaylighting>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>1.841</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5478,16 +5814,25 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="OfficeLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>5.222</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5504,16 +5849,25 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="GymLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>5.380</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5530,11 +5884,16 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="KitchenLighting1">
-            <LightingControlTypeDaylighting>None</LightingControlTypeDaylighting>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>2.170</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5551,16 +5910,25 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="CafeteriaLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>4.747</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5577,16 +5945,25 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="LibraryLighting1">
-            <LightingControlTypeDaylighting>Stepped Dimming</LightingControlTypeDaylighting>
             <DimmingCapability>
               <MinimumDimmingLightFraction>0.2</MinimumDimmingLightFraction>
               <MinimumDimmingPowerFraction>0.3</MinimumDimmingPowerFraction>
             </DimmingCapability>
-            <DaylightingControlSteps>3</DaylightingControlSteps>
             <PercentPremisesServed>1</PercentPremisesServed>
             <InstalledPower>5.583</InstalledPower>
             <OutsideLighting>false</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Daylighting>
+                  <ControlSensor>Photocell</ControlSensor>
+                  <ControlSteps>3</ControlSteps>
+                  <ControlStrategy>Stepped Dimming</ControlStrategy>
+                </Daylighting>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
             <LinkedPremises>
@@ -5603,11 +5980,18 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="ExteriorLighting1">
-            <LightingControlTypeTimer>Astronomical</LightingControlTypeTimer>
-            <LightingControlTypeDaylighting>None</LightingControlTypeDaylighting>
             <InstalledPower>0.15048</InstalledPower>
             <OutsideLighting>true</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Timer>
+                  <ControlStrategy>Astronomical</ControlStrategy>
+                </Timer>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Exterior</Location>
             <LinkedPremises>
@@ -5622,11 +6006,18 @@
             <Quantity>1</Quantity>
           </LightingSystem>
           <LightingSystem ID="ExteriorLighting2">
-            <LightingControlTypeTimer>Astronomical</LightingControlTypeTimer>
-            <LightingControlTypeDaylighting>None</LightingControlTypeDaylighting>
             <InstalledPower>3.340</InstalledPower>
             <OutsideLighting>true</OutsideLighting>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Timer>
+                  <ControlStrategy>Astronomical</ControlStrategy>
+                </Timer>
+                <OtherControlTechnology>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </OtherControlTechnology>
+              </Control>
+            </Controls>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Exterior</Location>
             <LinkedPremises>
@@ -5934,7 +6325,13 @@
             <PumpOperation>On Demand</PumpOperation>
             <PumpingConfiguration>Primary</PumpingConfiguration>
             <PumpApplication>Boiler</PumpApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Thermostat>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Thermostat>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -5948,7 +6345,13 @@
             <PumpOperation>On Demand</PumpOperation>
             <PumpingConfiguration>Primary</PumpingConfiguration>
             <PumpApplication>Domestic Hot Water</PumpApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Thermostat>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Thermostat>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -5963,7 +6366,13 @@
             <FanApplication>Supply</FanApplication>
             <FanControlType>Variable Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -5976,7 +6385,13 @@
             <FanApplication>Supply</FanApplication>
             <FanControlType>Variable Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -5989,7 +6404,13 @@
             <FanApplication>Supply</FanApplication>
             <FanControlType>Variable Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6002,7 +6423,13 @@
             <FanApplication>Supply</FanApplication>
             <FanControlType>Variable Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6015,7 +6442,13 @@
             <FanApplication>Supply</FanApplication>
             <FanControlType>Constant Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6028,7 +6461,13 @@
             <FanApplication>Supply</FanApplication>
             <FanControlType>Constant Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6041,7 +6480,13 @@
             <FanApplication>Supply</FanApplication>
             <FanControlType>Constant Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6055,6 +6500,13 @@
             <FanApplication>Exhaust</FanApplication>
             <FanControlType>Constant Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Always On</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Exterior</Location>
@@ -6068,6 +6520,13 @@
             <FanApplication>Exhaust</FanApplication>
             <FanControlType>Constant Volume</FanControlType>
             <MotorLocationRelativeToAirStream>true</MotorLocationRelativeToAirStream>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Always On</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Exterior</Location>
@@ -6081,7 +6540,13 @@
             <MotorEfficiency>0.924</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6093,7 +6558,13 @@
             <MotorEfficiency>0.924</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6105,7 +6576,13 @@
             <MotorEfficiency>0.924</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6117,7 +6594,13 @@
             <MotorEfficiency>0.924</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6129,7 +6612,13 @@
             <MotorEfficiency>0.865</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6141,7 +6630,13 @@
             <MotorEfficiency>0.895</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6153,7 +6648,13 @@
             <MotorEfficiency>0.895</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
-            <ControlTechnology>EMCS</ControlTechnology>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>EMCS</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6165,6 +6666,13 @@
             <MotorEfficiency>1.0</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Manual</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>
@@ -6176,6 +6684,13 @@
             <MotorEfficiency>1.0</MotorEfficiency>
             <DriveEfficiency>1</DriveEfficiency>
             <MotorApplication>Fan</MotorApplication>
+            <Controls>
+              <Control>
+                <Manual>
+                  <ControlStrategy>Manual</ControlStrategy>
+                </Manual>
+              </Control>
+            </Controls>
             <Quantity>1</Quantity>
             <PrimaryFuel>Electricity</PrimaryFuel>
             <Location>Interior</Location>

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -78,8 +78,8 @@ Below are the mapping for option 2 to demonstrate how the new format may look.
 
 BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/CoolingSources/CoolingSource/ControlTechnology
 
-| AT Field - Value     |
-|----------------------|-------------------------------------
+| AT Field - Value     | XPath								  |
+|----------------------|------------------------------------- |
 | Zone Controls - None | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Other/ControlTechnology/None |
 | Zone Controls - Manual Pneumatic Thermostat | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Pneumatic/ControlTechnology/Thermostat/ControlStrategy - Manual |
 | Zone Controls - Programmable DDC Thermostat | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/Thermostat/ControlStrategy |
@@ -89,7 +89,7 @@ BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolin
 | Central Plant - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/ECMS/ControlStrategy - Programmable |
 | Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Pneumatic/ControlTechnology/Other/ControlStrategy - Other |
 | Lighting Controls - Occupancy Sensor | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Occupancy/ControlStrategy |
-| Lighting Controls - Photocell | 
+| Lighting Controls - Photocell | auc:BuildingSync/auc:Facilities/auc:Facility/auc:Systems/auc:LightingSystems/auc:LightingSystem/auc:Controls_2/auc:LightingControl/auc:Digital/auc:ControlTechnology/auc:Photocell/auc:ControlStrategy - Other |
 | Lighting Controls - Timer | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Timer/ControlStrategy | 
 | Lighting Controls - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/ECMS/ControlStrategy |
 | Lighting Controls - Advanced | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Other/ControlStrategy - Advanced |

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -92,7 +92,7 @@ The remaining controls were lumped into a general control complex type with the 
 		* ... same as above ...
 	 	* OtherControlTechnologyName
 
-Their were several existing systems that had existing ControlTechnologies. These systems were updated with the ControlHVACType complex element. The systems included: HeatingSource, CoolingSource, Delivery, OtherHVACSystems, Solar, DomesticHotWater, DishwasherSystem, LaundrySystem, PumpSystem, FanSystems, MotorSystems, HeatRecoverySystem, Pool/Heated, WaterUse, ProcessLoads, PlugLoads, CriticalITSystems, ConveyanceSystems.
+Their were several existing systems that had existing ControlTechnologies. These systems were updated with the ControlGeneralType complex element. The systems included: HeatingSource, CoolingSource, Delivery, OtherHVACSystems, Solar, DomesticHotWater, DishwasherSystem, LaundrySystem, PumpSystem, FanSystems, MotorSystems, HeatRecoverySystem, Pool/Heated, WaterUse, ProcessLoads, PlugLoads, CriticalITSystems, ConveyanceSystems.
 
 The `PrimaryHVACControlStrategy` will be renamed to `PrimaryControlSystemType`.
 
@@ -104,25 +104,25 @@ Mapping of existing control technologies (old term) to newer terms.
 
 | Previous Field     | New XPath                 | Paired XPath             |
 |--------------------|---------------------------|------------------------- |
-| Programmable Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Programmable | None |
-| Manual Analog Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Manual | //element(ControlHVACType)/Thermostat/ControlSystemType/Analog | 
-| Manual Digital Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Manual | //element(ControlHVACType)/Thermostat/ControlSystemType/Digital | 
-| Manual On/Off | //element(ControlHVACType)/Manual/ControlStrategy - Manual | None |
-| EMCS | //element(ControlHVACType)/Thermostat/ControlStrategy - EMCS | None |
-| Always On | //element(ControlHVACType)/Thermostat/ControlStrategy - Always On | None |
-| Timer | //element(ControlHVACType)/Thermostat/ControlStrategy - Timer | None |
-| Other | //element(ControlHVACType)/Thermostat/ControlStrategy - Other | None |
-| Unknown | //element(ControlHVACType)/Thermostat/ControlStrategy - Unknown | None |
-| None | //element(ControlHVACType)/Thermostat/ControlStrategy - None | None |
+| Programmable Thermostat | //element(ControlGeneralType)/Thermostat/ControlStrategy - Programmable | None |
+| Manual Analog Thermostat | //element(ControlGeneralType)/Thermostat/ControlStrategy - Manual | //element(ControlGeneralType)/Thermostat/ControlSystemType/Analog | 
+| Manual Digital Thermostat | //element(ControlGeneralType)/Thermostat/ControlStrategy - Manual | //element(ControlGeneralType)/Thermostat/ControlSystemType/Digital | 
+| Manual On/Off | //element(ControlGeneralType)/Manual/ControlStrategy - Manual | None |
+| EMCS | //element(ControlGeneralType)/Thermostat/ControlStrategy - EMCS | None |
+| Always On | //element(ControlGeneralType)/Thermostat/ControlStrategy - Always On | None |
+| Timer | //element(ControlGeneralType)/Thermostat/ControlStrategy - Timer | None |
+| Other | //element(ControlGeneralType)/Thermostat/ControlStrategy - Other | None |
+| Unknown | //element(ControlGeneralType)/Thermostat/ControlStrategy - Unknown | None |
+| None | //element(ControlGeneralType)/Thermostat/ControlStrategy - None | None |
 
 
 | AT Field - Value     | XPath								  | Paired XPath            |
 |----------------------|--------------------------------------|------------------------ |
-| Zone Controls - None | //element(ControlHVACType)/Thermostat/ControlStrategy - None | None |
-| Zone Controls - Manual Pneumatic Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Manual | //element(ControlHVACType)/Thermostat/ControlSystemType/Pneumatic | 
-| Zone Controls - Programmable DDC Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Programmable | //element(ControlHVACType)/Thermostat/ControlSystemType/Digital |
-| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat | //element(ControlHVACType)/Thermostat/ControlSystemType/Digital | 
-| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat | //element(ControlHVACType)/Thermostat/ControlSystemType/Pneumatic |
+| Zone Controls - None | //element(ControlGeneralType)/Thermostat/ControlStrategy - None | None |
+| Zone Controls - Manual Pneumatic Thermostat | //element(ControlGeneralType)/Thermostat/ControlStrategy - Manual | //element(ControlGeneralType)/Thermostat/ControlSystemType/Pneumatic | 
+| Zone Controls - Programmable DDC Thermostat | //element(ControlGeneralType)/Thermostat/ControlStrategy - Programmable | //element(ControlGeneralType)/Thermostat/ControlSystemType/Digital |
+| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat | //element(ControlGeneralType)/Thermostat/ControlSystemType/Digital | 
+| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat | //element(ControlGeneralType)/Thermostat/ControlSystemType/Pneumatic |
 | Heating Central Plant - Direct Digital | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/ControlSystemType/Digital | |
 | Heating Central Plant - Building Automation | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/BuildingAutomationSystem | |
 | Heating Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/ControlSystemType/Pneumatic | |

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -1,0 +1,107 @@
+# Reconcile Controls
+
+## Overview
+
+The control elements in BuildingSync need to be updated to be more consistent and allow for more flexibility. The justification section outlines several of the items that need to be updated along with the reason/justification.
+
+
+## Justification
+
+Controls are under-defined within BuildingSync. First, the ability to specify that a system has multiple types of controls is not possible. Although it is ideal that each system only has one type of control, that is not always the case, especially when there can be more than one type of control strategy (e.g. timer and EMCS). Second, the controls only specify the control technology and often mixes the type of control system and control strategy. Third, when a system has customized controls (e.g. lighting systems), then the additional control elements are not part of the controls tag.
+
+The definitions of controllers has been updated to be the following:
+
+	* ControlSytemType - Type of controller (e.g. analog, digital, ddc, pneumatic).
+	* CommunicationProtocol - Method of communicating data over a computer network.
+	* ControlTechnology - Device that enables control of the system. (e.g. EMCS, thermostat, timer) [bedes](https://bedes.lbl.gov/bedes-online/control-technology)
+	* ControlStrategy - Control logic or strategy that is programed into the system. (e.g. schedules, manual, demand, aquastat) [bedes](https://bedes.lbl.gov/bedes-online/control-strategy)
+	
+
+* The element `BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/PrimaryHVACControlStrategy` is used to define the type of controller (e.g. pneumatic, BAS, or electronic). This element needs to be renamed to a more generic name such as `PrimaryHVACControlSystemType`.
+
+## Implementation
+
+There are two proposals that are in discussion--based on user feedback only one of these will be implemented and this proposal will be updated. The first proposal is a more simple approach designed to have the most flexibility but will require humans to ensure that valid combinations are present. The second proposal approach is an overhaul and allows for future extensibility.
+
+1. The ControlTechnology element will be renamed to simply controls made into a list (Controls) and the previous ControlTechnology element will be converted to Control and have sub-elements. In brief, the update will look like the following:
+
+	* Controls
+		* Control (unbounded)
+			* ControlSytemType
+			* CommunicationProtocol
+			* ControlTechnology
+			* ControlStrategy
+
+The difficulty with this proposal is that the 4 defined elements above have many invalid combinations (e.g. pneumatic/bacnet/thermostat/programmable). 
+
+2. The second proposed implementation will structure the controls based on their respective areas. This will allow for controls to be re-purposed based on lighting, HVAC, occupancy, or other. In each area, the controls are broken up into the conventional types such as pneumatic, digital, electronic, and other. Each of the types is further specified into the technologies, protocols, and strategies. The structure would look like the following:
+
+	* Controls
+		* HVACControl (unbounded)
+			* Pneumatic
+				* ControlTechnology 
+					* Thermostat
+						* ControlStrategy
+							- Always On
+							- Manual
+					* Timer
+						* ControlStrategy
+							- Always On
+							- Aquastat
+							- Demand
+							- Manual
+							- Programmable
+							- Scheduled
+					* Other
+						* ControlStrategy
+							- Always On
+							- Aquastat
+							- Demand
+							- Manual
+							- Programmable
+							- Scheduled
+			* Analog (see schema)
+			* DirectDigitalControl (see schema)
+			* Other (see schema)
+		* LightingControl (unbounded)
+		* OccupantBasedControl (unbounded)
+		* OtherControl (unbounded)
+
+All ControlStrategy elements will include the Other, Unknown, and None enumerations.
+With proposal 2, the lighting controls will be moved under the controls section, these include: LightingControlTypeOccupancy, LightingControlTypeTimer, LightingControlTypeDaylighting, LightingControlTypeManual. 
+
+** Note: The schema has this only stubbed out for the LightingSystem **
+
+## Mappings
+
+Below are the mapping for option 2 to demonstrate how the new format may look.
+
+BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/CoolingSources/CoolingSource/ControlTechnology
+
+| AT Field - Value     |
+|----------------------|-------------------------------------
+| Zone Controls - None | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Other/ControlTechnology/None |
+| Zone Controls - Manual Pneumatic Thermostat | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Pneumatic/ControlTechnology/Thermostat/ControlStrategy - Manual |
+| Zone Controls - Programmable DDC Thermostat | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/Thermostat/ControlStrategy |
+| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat |
+| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat |
+| Central Plant - Direct Digital | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/ECMS/ControlStrategy - Other |
+| Central Plant - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/ECMS/ControlStrategy - Programmable |
+| Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Pneumatic/ControlTechnology/Other/ControlStrategy - Other |
+| Lighting Controls - Occupancy Sensor | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Occupancy/ControlStrategy |
+| Lighting Controls - Photocell | 
+| Lighting Controls - Timer | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Timer/ControlStrategy | 
+| Lighting Controls - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/ECMS/ControlStrategy |
+| Lighting Controls - Advanced | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Other/ControlStrategy - Advanced |
+| Lighting Controls - Other | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Other/ControlStrategy - Unknown |
+
+
+## Questions
+
+Programmable and Scheduled are the same term in BEDES, see [programmable](https://bedes.lbl.gov/bedes-online/programmable) and [scheduled](https://bedes.lbl.gov/bedes-online/scheduled). There should only be a single term and recommend "Programmable" as it is more abstract. 
+
+## References
+
+* ASHRAE Handbook of Fundamentals Section 2.3 - Controllers
+* https://bedes.lbl.gov/bedes-online/control-strategy
+* https://bedes.lbl.gov/bedes-online/control-technology

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -100,6 +100,12 @@ BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolin
 
 Programmable and Scheduled are the same term in BEDES, see [programmable](https://bedes.lbl.gov/bedes-online/programmable) and [scheduled](https://bedes.lbl.gov/bedes-online/scheduled). There should only be a single term and recommend "Programmable" as it is more abstract. 
 
+## TODO
+
+* Determine if we should flip control technologies and control type
+* Plant controls
+* How to handle high-level ask if the building has analog, digital, or pneumatic
+* Do not put 0-10V as an enum (use voltage | current)
 ## References
 
 * ASHRAE Handbook of Fundamentals Section 2.3 - Controllers

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -144,10 +144,6 @@ For AT Zone Controls, the controls are specified at the zone level. It is recomm
 
 Programmable and Scheduled are the same term in BEDES, see [programmable](https://bedes.lbl.gov/bedes-online/programmable) and [scheduled](https://bedes.lbl.gov/bedes-online/scheduled). There should only be a single term and recommend "Programmable" as it is more abstract. This has been implemented.
 
-## TODO
-
-* Plant controls
-
 ## References
 
 * ASHRAE Handbook of Fundamentals Section 2.3 - Controllers

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -13,7 +13,7 @@ The definitions of controllers has been updated to be the following:
 
 	* ControlSytemType - Type of controller (e.g. analog, digital, ddc, pneumatic).
 	* CommunicationProtocol - Method of communicating data over a computer network.
-	* ControlTechnology - Device that enables control of the system. (e.g. EMCS, thermostat, timer) [bedes](https://bedes.lbl.gov/bedes-online/control-technology)
+	* ControlTechnology - Device that enables control of the system (e.g. BAS/EMCS, thermostat, timer). This will now be part of the control section and not explicity named. [bedes](https://bedes.lbl.gov/bedes-online/control-technology)
 	* ControlStrategy - Control logic or strategy that is programed into the system. (e.g. schedules, manual, demand, aquastat) [bedes](https://bedes.lbl.gov/bedes-online/control-strategy)
 	
 
@@ -21,24 +21,70 @@ The definitions of controllers has been updated to be the following:
 
 ## Implementation
 
-There are two proposals that are in discussion--based on user feedback only one of these will be implemented and this proposal will be updated. The first proposal is a more simple approach designed to have the most flexibility but will require humans to ensure that valid combinations are present. The second proposal approach is an overhaul and allows for future extensibility.
+The proposed implementation will include a significant restructuring of the controls sections to allow for more versatility and more specific control system characteristics.
 
-1. The ControlTechnology element will be renamed to simply controls made into a list (Controls) and the previous ControlTechnology element will be converted to Control and have sub-elements. In brief, the update will look like the following:
+
+The controls will be based on their respective areas (e.g. LightingControl, HVACControl, etc.). This will allow for controls to be re-purposed based on lighting, HVAC, occupancy, or other. In each area, the controls are broken up into the conventional types such as pneumatic, digital, electronic, and other. Each of the types is further specified into the technologies, protocols, and strategies. The structure would look like the following:
+
+The ControlType is a global complex type with the following elements that are referenced in multiple places:
+
+	* ControlType
+		* Analog
+			* CommunicationProtocol
+				* List of multiple analog protocols
+		* Digital
+			* CommunicationProtocol
+				* List of multiple digital protocols
+		* Pneumatic
+		* Other
+			* OtherCommunicationProtocol
+
+
+The Lighting System has the following updated controls section:
 
 	* Controls
 		* Control (unbounded)
-			* ControlSytemType
-			* CommunicationProtocol
-			* ControlTechnology
-			* ControlStrategy
+			* AdvancedPowerStrip
+				* ControlType
+				* ControlStrategy
+					* List of multiple lighting-based control strategies
+				* OtherControlStrategyName
+			* Daylighting
+				* ControlType
+				* ControlSensor
+					* List
+				* ControlSteps
+				* ControlStrategy
+				* OtherControlStrategyName
+			* Manual
+				* ... same as above ...
+			* Occupancy
+			 	* ... same as above ...
+			 	* ControlSensor
+			 		* IR, Ultrasonic, etc.
+			* Timer
+				* ... same as above ...
+			* OtherControlTechnology
+				* ... same as above ...
+			 	* OtherControlTechnologyName
 
-The difficulty with this proposal is that the 4 defined elements above have many invalid combinations (e.g. pneumatic/bacnet/thermostat/programmable). 
-
-2. The second proposed implementation will structure the controls based on their respective areas. This will allow for controls to be re-purposed based on lighting, HVAC, occupancy, or other. In each area, the controls are broken up into the conventional types such as pneumatic, digital, electronic, and other. Each of the types is further specified into the technologies, protocols, and strategies. The structure would look like the following:
+The HVAC Systems, specifically the HeatingSource ... to be completed.
 
 	* Controls
-		* HVACControl (unbounded)
-			* Pneumatic
+		* HVACControlType (unbounded)
+			* AdvancedPowerStrip
+				* CioAnalog
+					* CommunicationProtocol
+					* ControlStrategy
+						* 
+				* Digital
+				* Other
+			* Thermostat
+			* OtherControlTechnology
+
+
+
+
 				* ControlTechnology 
 					* Thermostat
 						* ControlStrategy
@@ -63,49 +109,65 @@ The difficulty with this proposal is that the 4 defined elements above have many
 			* Analog (see schema)
 			* DirectDigitalControl (see schema)
 			* Other (see schema)
-		* LightingControl (unbounded)
+		* LightingSystem
+							
+						* 
+
 		* OccupantBasedControl (unbounded)
 		* OtherControl (unbounded)
 
-All ControlStrategy elements will include the Other, Unknown, and None enumerations.
-With proposal 2, the lighting controls will be moved under the controls section, these include: LightingControlTypeOccupancy, LightingControlTypeTimer, LightingControlTypeDaylighting, LightingControlTypeManual. 
+Each functional area will be a complex type allowing for easy reuse. 
 
-** Note: The schema has this only stubbed out for the LightingSystem **
+All ControlStrategy elements will include the Other, Unknown, and None enumerations.
+
+Items under lighting controls will be moved under the new LightingControls section, these include: LightingControlTypeOccupancy, LightingControlTypeTimer, LightingControlTypeDaylighting, LightingControlTypeManual. 
+
 
 ## Mappings
 
-Below are the mapping for option 2 to demonstrate how the new format may look.
+Mapping of existing control technologies (old term) to newer terms.
 
-BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/CoolingSources/CoolingSource/ControlTechnology
-
-| AT Field - Value     | XPath								  |
-|----------------------|------------------------------------- |
-| Zone Controls - None | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Other/ControlTechnology/None |
-| Zone Controls - Manual Pneumatic Thermostat | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Pneumatic/ControlTechnology/Thermostat/ControlStrategy - Manual |
-| Zone Controls - Programmable DDC Thermostat | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/Thermostat/ControlStrategy |
-| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat |
-| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat |
-| Central Plant - Direct Digital | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/ECMS/ControlStrategy - Other |
-| Central Plant - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/ECMS/ControlStrategy - Programmable |
-| Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Pneumatic/ControlTechnology/Other/ControlStrategy - Other |
-| Lighting Controls - Occupancy Sensor | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Occupancy/ControlStrategy |
-| Lighting Controls - Photocell | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Photocell/ControlStrategy - Other |
-| Lighting Controls - Timer | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Timer/ControlStrategy | 
-| Lighting Controls - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/ECMS/ControlStrategy |
-| Lighting Controls - Advanced | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Other/ControlStrategy - Advanced |
-| Lighting Controls - Other | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Other/ControlStrategy - Unknown |
+| Previous Field     | New XPath                 | Paired XPath             |
+|--------------------|---------------------------|------------------------- |
+| Programmable Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Programmable | None |
+| Manual Analog Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Manual | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Analog | 
+| Manual Digital Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Manual | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Digital | 
+| Manual On/Off | //element(auc:ControlHVACType)/auc:Manual/auc:ControlStrategy - Manual | None |
+| EMCS | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - EMCS | None |
+| Always On | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Always On | None |
+| Timer | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Timer | None |
+| Other | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Other | None |
+| Unknown | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Unknown | None |
+| None | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - None | None |
 
 
-## Questions
+| AT Field - Value     | XPath								  | Paired XPath            |
+|----------------------|--------------------------------------|------------------------ |
+| Zone Controls - None | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - None | None |
+| Zone Controls - Manual Pneumatic Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Manual | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Pneumatic | 
+| Zone Controls - Programmable DDC Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Programmable | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Digital |
+| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Digital | 
+| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Pneumatic |
+| Central Plant - Direct Digital | | |
+| Central Plant - Building Automation | | |
+| Central Plant - Pneumatic Controls | | |
+| Lighting Controls - Manual | //element(auc:ControlLightingType)/auc:Manual | None |
+| Lighting Controls - Occupancy Sensor | //element(auc:ControlLightingType)/auc:Occupancy | None |
+| Lighting Controls - Photocell | //element(auc:ControlLightingType)/auc:Daylighting/auc:ControlSensor - Photocell | None | 
+| Lighting Controls - Timer | //element(auc:ControlLightingType)/auc:Timer | None |
+| Lighting Controls - Building Automation System | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlStrategy - Programmable | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlType/auc:Digital |
+| Lighting Controls - Advanced | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlStrategy - None | None |
+| Lighting Controls - Other | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlStrategy - Other | None |
 
-Programmable and Scheduled are the same term in BEDES, see [programmable](https://bedes.lbl.gov/bedes-online/programmable) and [scheduled](https://bedes.lbl.gov/bedes-online/scheduled). There should only be a single term and recommend "Programmable" as it is more abstract. 
+Programmable and Scheduled are the same term in BEDES, see [programmable](https://bedes.lbl.gov/bedes-online/programmable) and [scheduled](https://bedes.lbl.gov/bedes-online/scheduled). There should only be a single term and recommend "Programmable" as it is more abstract. This has been implemented.
 
 ## TODO
 
-* Determine if we should flip control technologies and control type
 * Plant controls
 * How to handle high-level ask if the building has analog, digital, or pneumatic
-* Do not put 0-10V as an enum (use voltage | current)
+* BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/CoolingSources/CoolingSource/ControlTechnology
+
+
 ## References
 
 * ASHRAE Handbook of Fundamentals Section 2.3 - Controllers

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -89,7 +89,7 @@ BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolin
 | Central Plant - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/DirectDigitalControl/ControlTechnology/ECMS/ControlStrategy - Programmable |
 | Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/HVACControl/Pneumatic/ControlTechnology/Other/ControlStrategy - Other |
 | Lighting Controls - Occupancy Sensor | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Occupancy/ControlStrategy |
-| Lighting Controls - Photocell | auc:BuildingSync/auc:Facilities/auc:Facility/auc:Systems/auc:LightingSystems/auc:LightingSystem/auc:Controls_2/auc:LightingControl/auc:Digital/auc:ControlTechnology/auc:Photocell/auc:ControlStrategy - Other |
+| Lighting Controls - Photocell | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Photocell/ControlStrategy - Other |
 | Lighting Controls - Timer | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Timer/ControlStrategy | 
 | Lighting Controls - Building Automation System | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/ECMS/ControlStrategy |
 | Lighting Controls - Advanced | BuildingSync/Facilities/Facility/Systems/LightingSystems/LightingSystem/Controls_2/LightingControl/Digital/ControlTechnology/Other/ControlStrategy - Advanced |

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -52,7 +52,7 @@ The Lighting System has the following updated controls section:
 			* Daylighting
 				* ControlType
 				* ControlSensor
-					* List
+					* List of multiple lighting-based control strategies
 				* ControlSteps
 				* ControlStrategy
 				* OtherControlStrategyName
@@ -67,61 +67,36 @@ The Lighting System has the following updated controls section:
 			* OtherControlTechnology
 				* ... same as above ...
 			 	* OtherControlTechnologyName
-
-The HVAC Systems, specifically the HeatingSource ... to be completed.
-
-	* Controls
-		* HVACControlType (unbounded)
-			* AdvancedPowerStrip
-				* CioAnalog
-					* CommunicationProtocol
-					* ControlStrategy
-						* 
-				* Digital
-				* Other
-			* Thermostat
-			* OtherControlTechnology
-
-
-
-
-				* ControlTechnology 
-					* Thermostat
-						* ControlStrategy
-							- Always On
-							- Manual
-					* Timer
-						* ControlStrategy
-							- Always On
-							- Aquastat
-							- Demand
-							- Manual
-							- Programmable
-							- Scheduled
-					* Other
-						* ControlStrategy
-							- Always On
-							- Aquastat
-							- Demand
-							- Manual
-							- Programmable
-							- Scheduled
-			* Analog (see schema)
-			* DirectDigitalControl (see schema)
-			* Other (see schema)
-		* LightingSystem
-							
-						* 
-
-		* OccupantBasedControl (unbounded)
-		* OtherControl (unbounded)
-
-Each functional area will be a complex type allowing for easy reuse. 
-
-All ControlStrategy elements will include the Other, Unknown, and None enumerations.
+			 	* OtherControlStrategyName
 
 Items under lighting controls will be moved under the new LightingControls section, these include: LightingControlTypeOccupancy, LightingControlTypeTimer, LightingControlTypeDaylighting, LightingControlTypeManual. 
 
+The remaining controls were lumped into a general control complex type with the following structure:
+
+	* AdvancedPowerStrip
+		* ControlType
+		* ControlStrategy
+			* List of multiple general control strategies
+		* OtherControlStrategyName
+	* Manual
+		* ... same as above ...
+	* Occupancy
+	 	* ... same as above ...
+	 	* ControlSensor
+	 		* IR, Ultrasonic, etc.
+	* Timer
+		* ... same as above ...
+	* Thermostat
+		* ... same as above ...
+	* OtherControlTechnology
+		* ... same as above ...
+	 	* OtherControlTechnologyName
+
+Their were several existing systems that had existing ControlTechnologies. These systems were updated with the ControlHVACType complex element. The systems included: HeatingSource, CoolingSource, Delivery, OtherHVACSystems, Solar, DomesticHotWater, DishwasherSystem, LaundrySystem, PumpSystem, FanSystems, MotorSystems, HeatRecoverySystem, Pool/Heated, WaterUse, ProcessLoads, PlugLoads, CriticalITSystems, ConveyanceSystems.
+
+The `PrimaryHVACControlStrategy` will be renamed to `PrimaryControlSystemType`.
+
+The BuildingAutomationSystem element was made global and repeated in the HeatingPlant, CoolingPlant, CondenserPlant to allow the user to specify that the system is connected to a BAS/EMCS.
 
 ## Mappings
 
@@ -129,44 +104,47 @@ Mapping of existing control technologies (old term) to newer terms.
 
 | Previous Field     | New XPath                 | Paired XPath             |
 |--------------------|---------------------------|------------------------- |
-| Programmable Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Programmable | None |
-| Manual Analog Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Manual | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Analog | 
-| Manual Digital Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Manual | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Digital | 
-| Manual On/Off | //element(auc:ControlHVACType)/auc:Manual/auc:ControlStrategy - Manual | None |
-| EMCS | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - EMCS | None |
-| Always On | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Always On | None |
-| Timer | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Timer | None |
-| Other | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Other | None |
-| Unknown | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Unknown | None |
-| None | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - None | None |
+| Programmable Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Programmable | None |
+| Manual Analog Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Manual | //element(ControlHVACType)/Thermostat/ControlSystemType/Analog | 
+| Manual Digital Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Manual | //element(ControlHVACType)/Thermostat/ControlSystemType/Digital | 
+| Manual On/Off | //element(ControlHVACType)/Manual/ControlStrategy - Manual | None |
+| EMCS | //element(ControlHVACType)/Thermostat/ControlStrategy - EMCS | None |
+| Always On | //element(ControlHVACType)/Thermostat/ControlStrategy - Always On | None |
+| Timer | //element(ControlHVACType)/Thermostat/ControlStrategy - Timer | None |
+| Other | //element(ControlHVACType)/Thermostat/ControlStrategy - Other | None |
+| Unknown | //element(ControlHVACType)/Thermostat/ControlStrategy - Unknown | None |
+| None | //element(ControlHVACType)/Thermostat/ControlStrategy - None | None |
 
 
 | AT Field - Value     | XPath								  | Paired XPath            |
 |----------------------|--------------------------------------|------------------------ |
-| Zone Controls - None | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - None | None |
-| Zone Controls - Manual Pneumatic Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Manual | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Pneumatic | 
-| Zone Controls - Programmable DDC Thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlStrategy - Programmable | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Digital |
-| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Digital | 
-| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat | //element(auc:ControlHVACType)/auc:Thermostat/auc:ControlType/auc:Pneumatic |
-| Central Plant - Direct Digital | | |
-| Central Plant - Building Automation | | |
-| Central Plant - Pneumatic Controls | | |
-| Lighting Controls - Manual | //element(auc:ControlLightingType)/auc:Manual | None |
-| Lighting Controls - Occupancy Sensor | //element(auc:ControlLightingType)/auc:Occupancy | None |
-| Lighting Controls - Photocell | //element(auc:ControlLightingType)/auc:Daylighting/auc:ControlSensor - Photocell | None | 
-| Lighting Controls - Timer | //element(auc:ControlLightingType)/auc:Timer | None |
-| Lighting Controls - Building Automation System | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlStrategy - Programmable | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlType/auc:Digital |
-| Lighting Controls - Advanced | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlStrategy - None | None |
-| Lighting Controls - Other | //element(auc:ControlLightingType)/auc:OtherControlTechnology/auc:ControlStrategy - Other | None |
+| Zone Controls - None | //element(ControlHVACType)/Thermostat/ControlStrategy - None | None |
+| Zone Controls - Manual Pneumatic Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Manual | //element(ControlHVACType)/Thermostat/ControlSystemType/Pneumatic | 
+| Zone Controls - Programmable DDC Thermostat | //element(ControlHVACType)/Thermostat/ControlStrategy - Programmable | //element(ControlHVACType)/Thermostat/ControlSystemType/Digital |
+| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat | //element(ControlHVACType)/Thermostat/ControlSystemType/Digital | 
+| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat | //element(ControlHVACType)/Thermostat/ControlSystemType/Pneumatic |
+| Heating Central Plant - Direct Digital | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/ControlSystemType/Digital | |
+| Heating Central Plant - Building Automation | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/BuildingAutomationSystem | |
+| Heating Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/ControlSystemType/Pneumatic | |
+| Cooling Central Plant - Direct Digital | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/CoolingPlants/CoolingPlant/ControlSystemType/Digital | |
+| Cooling Central Plant - Building Automation | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/CoolingPlants/CoolingPlant/BuildingAutomationSystem | |
+| Cooling Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/CoolingPlants/CoolingPlant/ControlSystemType/Pneumatic | |
+| Condenser Central Plant - Direct Digital | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/CondenserPlants/CondenserPlant/ControlSystemType/Digital | |
+| Condenser Central Plant - Building Automation | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/CondenserPlants/CondenserPlant/BuildingAutomationSystem | |
+| Condenser Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/CondenserPlants/CondenserPlant/ControlSystemType/Pneumatic  | |
+| Lighting Controls - Manual | //element(ControlLightingType)/Manual | None |
+| Lighting Controls - Occupancy Sensor | //element(ControlLightingType)/Occupancy | None |
+| Lighting Controls - Photocell | //element(ControlLightingType)/Daylighting/ControlSensor - Photocell | None | 
+| Lighting Controls - Timer | //element(ControlLightingType)/Timer | None |
+| Lighting Controls - Building Automation System | //element(ControlLightingType)/OtherControlTechnology/ControlStrategy - Programmable | //element(ControlLightingType)/OtherControlTechnology/ControlSystemType/Digital |
+| Lighting Controls - Advanced | //element(ControlLightingType)/OtherControlTechnology/ControlStrategy - None | None |
+| Lighting Controls - Other | //element(ControlLightingType)/OtherControlTechnology/ControlStrategy - Other | None |
 
 Programmable and Scheduled are the same term in BEDES, see [programmable](https://bedes.lbl.gov/bedes-online/programmable) and [scheduled](https://bedes.lbl.gov/bedes-online/scheduled). There should only be a single term and recommend "Programmable" as it is more abstract. This has been implemented.
 
 ## TODO
 
 * Plant controls
-* How to handle high-level ask if the building has analog, digital, or pneumatic
-* BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/CoolingSources/CoolingSource/ControlTechnology
-
 
 ## References
 

--- a/proposals/2019/Controls.md
+++ b/proposals/2019/Controls.md
@@ -116,13 +116,15 @@ Mapping of existing control technologies (old term) to newer terms.
 | None | //element(ControlGeneralType)/Thermostat/ControlStrategy - None | None |
 
 
+For AT Zone Controls, the controls are specified at the zone level. It is recommended to keep the HeatingSource/Controls and the CoolingSource/Controls in sync.
+
 | AT Field - Value     | XPath								  | Paired XPath            |
 |----------------------|--------------------------------------|------------------------ |
-| Zone Controls - None | //element(ControlGeneralType)/Thermostat/ControlStrategy - None | None |
-| Zone Controls - Manual Pneumatic Thermostat | //element(ControlGeneralType)/Thermostat/ControlStrategy - Manual | //element(ControlGeneralType)/Thermostat/ControlSystemType/Pneumatic | 
-| Zone Controls - Programmable DDC Thermostat | //element(ControlGeneralType)/Thermostat/ControlStrategy - Programmable | //element(ControlGeneralType)/Thermostat/ControlSystemType/Digital |
-| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat | //element(ControlGeneralType)/Thermostat/ControlSystemType/Digital | 
-| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat | //element(ControlGeneralType)/Thermostat/ControlSystemType/Pneumatic |
+| Zone Controls - None | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/HeatingSources/HeatingSource/Controls/Control/Thermostat/ControlStrategy - None | None |
+| Zone Controls - Manual Pneumatic Thermostat | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/HeatingSources/HeatingSource/Controls/Control/Thermostat/ControlStrategy - Manual | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/HeatingSources/HeatingSource/Controls/Control/Thermostat/ControlSystemType/Pneumatic | 
+| Zone Controls - Programmable DDC Thermostat |BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/HeatingSources/HeatingSource/Controls/Control/Thermostat/ControlStrategy - Programmable | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/HeatingSources/HeatingSource/Controls/Control/Thermostat/ControlSystemType/Digital |
+| Zone Controls - Direct Digital Controls | Needs to be selected with the thermostat |BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/HeatingSources/HeatingSource/Controls/Control/Thermostat/ControlSystemType/Digital | 
+| Zone Controls - Pneumatic Controls | Needs to be selected with the thermostat | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/HeatingAndCoolingSystems/HeatingSources/HeatingSource/Controls/Control/Thermostat/ControlSystemType/Pneumatic |
 | Heating Central Plant - Direct Digital | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/ControlSystemType/Digital | |
 | Heating Central Plant - Building Automation | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/BuildingAutomationSystem | |
 | Heating Central Plant - Pneumatic Controls | BuildingSync/Facilities/Facility/Systems/HVACSystems/HVACSystem/Plants/HeatingPlants/HeatingPlant/ControlSystemType/Pneumatic | |

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Validate Examples' do
 
       errors = []
       @xsd.validate(doc).each do |error|
-        errors << { file: xml, error: error }
+        errors << {file: xml, error: error}
       end
       unless errors.size.zero?
         puts "  There were #{errors.size} errors!"
@@ -42,6 +42,31 @@ RSpec.describe 'No Tabs in Examples' do
       errors = []
       if File.read(xml).include? "\t"
         errors << "File #{xml} includes tabs, please remove the Tabs (run 'rake remove_tabs')"
+      end
+
+      unless errors.size.zero?
+        puts "  There were #{errors.size} errors!"
+        pp errors
+      end
+
+      total_errors += errors.size
+
+      puts "\n"
+    end
+
+    expect(total_errors).to eq 0
+  end
+end
+
+RSpec.describe 'No XMLSpy content' do
+  it 'should not have any XMLSpy comments' do
+    total_errors = 0
+    Dir['examples/*.xml', 'BuildingSync.xsd'].each do |xml|
+      puts "Checking for XMLSpy in file: #{xml}"
+
+      errors = []
+      if File.read(xml).include? "XMLSpy"
+        errors << "File #{xml} includes XMLSpy, please remove the offending lines (run 'rake remove_tabs')"
       end
 
       unless errors.size.zero?


### PR DESCRIPTION
There are two proposals for refactoring the concept of controls in BSync. The options are in the LightingSystem and named Controls_1 and Controls_2. Make sure to review the proposal as it contains initial mappings.

It is best to checkout this branch and review it in a schema editor.