### PR TITLE
Remove trailing whitespace from "Laboratory " [sic]

### DIFF
--- a/BuildingSync.json
+++ b/BuildingSync.json
@@ -10331,7 +10331,7 @@
 						"Food sales",
 						"Laboratory-Testing",
 						"Laboratory-Medical",
-						"Laboratory ",
+						"Laboratory",
 						"Vivarium",
 						"Office",
 						"Bank",

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -14934,7 +14934,7 @@
         <xs:enumeration value="Food sales"/>
         <xs:enumeration value="Laboratory-Testing"/>
         <xs:enumeration value="Laboratory-Medical"/>
-        <xs:enumeration value="Laboratory "/>
+        <xs:enumeration value="Laboratory"/>
         <xs:enumeration value="Vivarium"/>
         <xs:enumeration value="Office"/>
         <xs:enumeration value="Bank"/>


### PR DESCRIPTION
In the list of enumerations for the `auc:OccupancyClassification` element, the trailing whitespace in the term "Laboratory " [sic] is removed.
