### PR TITLE
Add <xs:complexType> child element to definition of "Pneumatic" element

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -17068,7 +17068,7 @@
           <xs:annotation>
             <xs:documentation>Pneumatic-based controls.</xs:documentation>
           </xs:annotation>
-          <xs:complexType></xs:complexType>
+          <xs:complexType/>
         </xs:element>
         <xs:element name="Other">
           <xs:annotation>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -17073,6 +17073,7 @@
           <xs:annotation>
             <xs:documentation>Pneumatic-based controls.</xs:documentation>
           </xs:annotation>
+          <xs:complexType></xs:complexType>
         </xs:element>
         <xs:element name="Other">
           <xs:annotation>

--- a/examples/BuildingSync Website Invalid Schema.xml
+++ b/examples/BuildingSync Website Invalid Schema.xml
@@ -183,7 +183,7 @@
             </auc:OtherHVACType>
             <auc:LinkedDeliveryIDs>
               <auc:LinkedDeliveryID>Delivery-70234392832520</auc:LinkedDeliveryID>
-            <auc:LinkedDeliveryIDs>
+            </auc:LinkedDeliveryIDs>
             <auc:UserDefinedFields>
               <auc:UserDefinedField>
                 <auc:FieldName>Type</auc:FieldName>


### PR DESCRIPTION
When `BuildingSync.xsd` is converted to Ruby using the `xsd2ruby.rb` script from soap4r, the class that corresponds to the "Pneumatic" element is not created because there is no `<xs:simpleType>` or `<xs:complexType>` element in the definition (which soap4r appears to need).