### PR TITLE
Pluralize and rename PrimaryHVACControlSystemType Element to HVACControlSystemType

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6992,19 +6992,28 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="PrimaryHVACControlSystemType" minOccurs="0">
+      <xs:element name="HVACControlSystemTypes" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Primary HVAC equipment control strategy.</xs:documentation>
+          <xs:documentation>HVAC equipment control strategies.</xs:documentation>
         </xs:annotation>
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="Analog"/>
-            <xs:enumeration value="Digital"/>
-            <xs:enumeration value="Pneumatic"/>
-            <xs:enumeration value="Other"/>
-            <xs:enumeration value="Unknown"/>
-          </xs:restriction>
-        </xs:simpleType>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="HVACControlSystemType" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>HVAC equipment control strategy.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="Analog"/>
+                  <xs:enumeration value="Digital"/>
+                  <xs:enumeration value="Pneumatic"/>
+                  <xs:enumeration value="Other"/>
+                  <xs:enumeration value="Unknown"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
       </xs:element>
       <xs:element ref="auc:LinkedPremises" minOccurs="0"/>
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>

--- a/proposals/2019/Pluralize PrimaryHVACControlSystemType.md
+++ b/proposals/2019/Pluralize PrimaryHVACControlSystemType.md
@@ -1,0 +1,23 @@
+# PrimaryHVACControlSystemType - Pluralize
+
+## Overview
+
+Pluralize the `auc:PrimaryHVACControlSystemType` element.
+
+## Justification
+
+In Audit Template, it is possible for HVAC equipment to have multiple control strategies.
+
+## Implementation
+
+This proposal is to:
+
+1. Rename the `auc:PrimaryHVACControlSystemType` element to `auc:HVACControlSystemType`.
+
+2. Add the `auc:HVACControlSystemTypes` element to the `auc:HVACSystemType` element.
+
+2. Move the renamed `auc:HVACControlSystemType` to the new `auc:HVACControlSystemTypes` element.
+
+## References
+
+n/a


### PR DESCRIPTION
See `proposals/2019/Pluralize PrimaryHVACControlSystemType.md` for details.