### PR TITLE
Remove `minOccurs="1"` constraint for `auc:AllResourceTotal` element

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -2988,7 +2988,7 @@
       <xs:element name="AllResourceTotals" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>


### PR DESCRIPTION
This resolves a bug in XML generation using Soap4R-autogenerated code.

Specifically, the "minOccurs" constraint causes the XML generator to always write a `auc:AllResourceTotals` element, even if it does not contain any `auc:AllResourceTotal` child elements, resulting in a schema validation error.

This is/was the only occurrence of `minOccurs="1"` in the XSD file.