### PR TITLE
feat/require version attribute with semantic versioning restriction

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -408,6 +408,12 @@
       <xs:attribute name="version" use="required">
         <xs:simpleType>
           <xs:restriction base="xs:string">
+            <xs:enumeration value="2.0.0-legacy"/>
+            <xs:enumeration value="0.2.0"/>
+            <xs:enumeration value="0.3.0"/>
+            <xs:enumeration value="1.0.0"/>
+            <xs:enumeration value="2.0.0-pr1"/>
+            <xs:enumeration value="2.0.0-pr2"/>
             <xs:enumeration value="2.0.0"/>
           </xs:restriction>
         </xs:simpleType>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -405,6 +405,13 @@
           </xs:complexType>
         </xs:element>
       </xs:sequence>
+      <xs:attribute name="version" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(\-[a-zA-Z0-9\.]+)?(\+[a-zA-Z0-9\.]+)?"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:complexType name="SiteType">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -407,7 +407,7 @@
       </xs:sequence>
       <xs:attribute name="version" use="required">
         <xs:annotation>
-          <xs:documentation>The versions are sorted by official release data (reverse order).  Note that semantic versioning for BuildingSync was reset in 2016.  v2.0.0-legacy is the last official release of the schema before the version reset and is available in the schema repository: https://github.com/BuildingSync/schema/releases/tag/v2.0.0-legacy.  Since then, semantic versioning started at the v0.2.0 release and progresses as expected.</xs:documentation>
+          <xs:documentation>The versions are sorted by official release date (reverse order).  Note that semantic versioning for BuildingSync was reset in 2016.  v2.0.0-legacy is the last official release of the schema before the version reset and is available in the schema repository: https://github.com/BuildingSync/schema/releases/tag/v2.0.0-legacy.  Since then, semantic versioning started at the v0.2.0 release and progresses as expected.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -408,7 +408,7 @@
       <xs:attribute name="version" use="required">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(\-[a-zA-Z0-9\.]+)?(\+[a-zA-Z0-9\.]+)?"/>
+            <xs:enumeration value="2.0.0"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -406,6 +406,9 @@
         </xs:element>
       </xs:sequence>
       <xs:attribute name="version" use="required">
+        <xs:annotation>
+          <xs:documentation>The versions are sorted by official release data (reverse order).  Note that semantic versioning for BuildingSync was reset in 2016.  v2.0.0-legacy is the last official release of the schema before the version reset and is available in the schema repository: https://github.com/BuildingSync/schema/releases/tag/v2.0.0-legacy.  Since then, semantic versioning started at the v0.2.0 release and progresses as expected.</xs:documentation>
+        </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:enumeration value="2.0.0-legacy"/>

--- a/examples/ASHRAE 211 Export.xml
+++ b/examples/ASHRAE 211 Export.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>

--- a/examples/AT_BRICR_audit_report.xml
+++ b/examples/AT_BRICR_audit_report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-70345309763860">
       <auc:Sites>

--- a/examples/AT_example_NYC_audit_report_property.xml
+++ b/examples/AT_example_NYC_audit_report_property.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-70267026338740">
       <auc:Sites>

--- a/examples/AT_example_SF_audit_report.xml
+++ b/examples/AT_example_SF_audit_report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-70267093073500">
       <auc:Sites>

--- a/examples/BuildingSync Website Invalid Schema.xml
+++ b/examples/BuildingSync Website Invalid Schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-1">
       <auc:PremisesName>Example Building</auc:PremisesName>

--- a/examples/BuildingSync Website Valid Schema.xml
+++ b/examples/BuildingSync Website Valid Schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <auc:Facilities>
     <auc:Facility>
       <auc:Sites>

--- a/examples/CMS Woodlawn Campus.xml
+++ b/examples/CMS Woodlawn Campus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Programs>
     <Program>
       <ProgramDate>2008-01-01</ProgramDate>

--- a/examples/DC GSA Headquarters.xml
+++ b/examples/DC GSA Headquarters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility ID="FirstFuel">
       <Sites>

--- a/examples/Golden Test File.xml
+++ b/examples/Golden Test File.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This example file is meant to cover the majority of the functionality of New York Local Law 87-->
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>

--- a/examples/Multi-Facility Shared Systems.xml
+++ b/examples/Multi-Facility Shared Systems.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>

--- a/examples/MultitenantBySubsections.xml
+++ b/examples/MultitenantBySubsections.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- "High-level" approach separating out floor areas by tenant -->
 <!-- Missing Data That We Still Want: Ownership of building -->
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>

--- a/examples/NIST Gaithersburg Campus.xml
+++ b/examples/NIST Gaithersburg Campus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>

--- a/examples/Norfolk Federal Building.xml
+++ b/examples/Norfolk Federal Building.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>

--- a/examples/Reference Building - Primary School.xml
+++ b/examples/Reference Building - Primary School.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility ID="Audit1">
       <Sites>

--- a/examples/Richmond Federal Building.xml
+++ b/examples/Richmond Federal Building.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
   <Facilities>
     <Facility>
       <Sites>


### PR DESCRIPTION
it is maybe not 100% correct regex for checking semantic versioning, but seeing as XML has its own [flavor of regex](https://www.regular-expressions.info/xml.html), I think it works.

Passed:
- 0.1.0
- 0.1.0+build
- 0.1.0+build.t3st
- 0.1.0-pr3
- 0.1.0-pr3.test
- 0.1.0-pr3.test+build.t3st

Rejected:
- 00.1.0
- 0.01.0
- 0.1