### PR TITLE
update OccupantQuantityType enumerations with definitions

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -15301,7 +15301,7 @@
                   <xs:restriction base="xs:string">
                     <xs:enumeration value="Peak total occupants">
                       <xs:annotation>
-                        <xs:documentation>This is the design occupancy of the premise (per Standard 211-2018 5.3.4.d).</xs:documentation>
+                        <xs:documentation>This is the design occupancy of the premise (per SPC 211 Standard for Commercial Building Energy Audits section 5.3.4.d).</xs:documentation>
                       </xs:annotation>
                     </xs:enumeration>
                     <xs:enumeration value="Adults"/>
@@ -15317,7 +15317,7 @@
                     <xs:enumeration value="Capacity percentage"/>
                     <xs:enumeration value="Normal occupancy">
                       <xs:annotation>
-                        <xs:documentation>This is the normal occupancy of the premise (per Standard 211-2018 5.3.4.d).  It can also be thought of as the average occupancy, i.e. the average number of people in the premise at any singular point in time.</xs:documentation>
+                        <xs:documentation>This is the normal occupancy of the premise (per SPC 211 Standard for Commercial Building Energy Audits section 5.3.4.d).  It can also be thought of as the average occupancy, i.e. the average number of people in the premise at any singular point in time.</xs:documentation>
                       </xs:annotation>
                     </xs:enumeration>
                   </xs:restriction>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -15299,7 +15299,11 @@
                 </xs:annotation>
                 <xs:simpleType>
                   <xs:restriction base="xs:string">
-                    <xs:enumeration value="Peak total occupants"/>
+                    <xs:enumeration value="Peak total occupants">
+                      <xs:annotation>
+                        <xs:documentation>This is the design occupancy of the premise (per Standard 211-2018 5.3.4.d).</xs:documentation>
+                      </xs:annotation>
+                    </xs:enumeration>
                     <xs:enumeration value="Adults"/>
                     <xs:enumeration value="Children"/>
                     <xs:enumeration value="Average residents"/>
@@ -15311,6 +15315,11 @@
                     <xs:enumeration value="Licensed beds"/>
                     <xs:enumeration value="Capacity"/>
                     <xs:enumeration value="Capacity percentage"/>
+                    <xs:enumeration value="Normal occupancy">
+                      <xs:annotation>
+                        <xs:documentation>This is the normal occupancy of the premise (per Standard 211-2018 5.3.4.d).  It can also be thought of as the average occupancy, i.e. the average number of people in the premise at any singular point in time.</xs:documentation>
+                      </xs:annotation>
+                    </xs:enumeration>
                   </xs:restriction>
                 </xs:simpleType>
               </xs:element>


### PR DESCRIPTION
ASHRAE 211 5.3.4.d refers to two OccupantQuantity definitions:
- Design occupancy
- Normal occupancy

There previously did not appear to be an enumeration in line with 'Normal occupancy', so this PR adds that.  Also adds documentation so that users understand exactly which enumerations to use.