### PR TITLE
Add None enum to ReheatSource

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6790,6 +6790,7 @@
                                           <xs:enumeration value="Heating plant"/>
                                           <xs:enumeration value="Local electric resistance"/>
                                           <xs:enumeration value="Local gas"/>
+                                          <xs:enumeration value="None"/>
                                           <xs:enumeration value="Other"/>
                                           <xs:enumeration value="Unknown"/>
                                         </xs:restriction>


### PR DESCRIPTION
Allow documents to have a `auc:ReheatSource` of None in `auc:Delivery`