### PR TITLE
Add None enum to AirSideEconomizerType

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -16452,6 +16452,7 @@
                   <xs:enumeration value="Enthalpy"/>
                   <xs:enumeration value="Demand controlled ventilation"/>
                   <xs:enumeration value="Nonintegrated"/>
+                  <xs:enumeration value="None"/>
                   <xs:enumeration value="Other"/>
                   <xs:enumeration value="Unknown"/>
                 </xs:restriction>


### PR DESCRIPTION
Allow documents to have a `auc:AirSideEconomizerType` of None in `auc:Delivery`