### PR TITLE
Add None enum to WaterSideEconomizerType

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -16023,6 +16023,7 @@
         <xs:enumeration value="Series Plate and Frame Heat Exchanger"/>
         <xs:enumeration value="Strainer Cycle"/>
         <xs:enumeration value="Thermo Cycle"/>
+        <xs:enumeration value="None"/>
         <xs:enumeration value="Other"/>
         <xs:enumeration value="Unknown"/>
       </xs:restriction>


### PR DESCRIPTION
This is to match the same enum added for AirSideEconomizer in #229 