### PR TITLE
Change OutputCapacity for HeatingSource and HeatingPlant types

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -7273,18 +7273,32 @@
                   </xs:simpleContent>
                 </xs:complexType>
               </xs:element>
-              <xs:element name="OutputCapacity" minOccurs="0">
-                <xs:annotation>
-                  <xs:documentation>Output capacity of equipment.</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                  <xs:simpleContent>
-                    <xs:extension base="xs:decimal">
-                      <xs:attribute ref="auc:Source"/>
-                    </xs:extension>
-                  </xs:simpleContent>
-                </xs:complexType>
-              </xs:element>
+              <xs:choice>
+                <xs:element name="OutputCapacity" minOccurs="0">
+                  <xs:annotation>
+                    <xs:documentation>Output capacity of equipment. WARNING: This element is being deprecated, use Capacity instead</xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:decimal">
+                        <xs:attribute ref="auc:Source"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="Capacity" minOccurs="0">
+                  <xs:annotation>
+                    <xs:documentation>Output capacity of equipment.</xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:decimal">
+                        <xs:attribute ref="auc:Source"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
               <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
               <xs:element name="NumberOfHeatingStages" minOccurs="0">
                 <xs:annotation>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -4355,7 +4355,7 @@
       </xs:element>
       <xs:element name="IntervalFrequency" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Indicates frequency of data that's available for a given variable. Data that's available can range from 10 minute interval to annual. This interval frequency can be applied to resource or other time series data like weather.</xs:documentation>
+          <xs:documentation>Indicates frequency of data that's available for a given variable. Data that's available can range from 1 minute interval to annual. This interval frequency can be applied to resource or other time series data like weather.</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -7506,18 +7506,32 @@
                   </xs:restriction>
                 </xs:simpleType>
               </xs:element>
-              <xs:element name="OutputCapacity" minOccurs="0">
-                <xs:annotation>
-                  <xs:documentation>Output capacity of equipment.</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                  <xs:simpleContent>
-                    <xs:extension base="xs:decimal">
-                      <xs:attribute ref="auc:Source"/>
-                    </xs:extension>
-                  </xs:simpleContent>
-                </xs:complexType>
-              </xs:element>
+              <xs:choice>
+                <xs:element name="OutputCapacity" minOccurs="0">
+                  <xs:annotation>
+                    <xs:documentation>Output capacity of equipment. WARNING: This element is being deprecated, use Capacity instead</xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:decimal">
+                        <xs:attribute ref="auc:Source"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="Capacity" minOccurs="0">
+                  <xs:annotation>
+                    <xs:documentation>Output capacity of equipment.</xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:decimal">
+                        <xs:attribute ref="auc:Source"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
               <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
               <xs:element name="AnnualHeatingEfficiencyValue" minOccurs="0">
                 <xs:annotation>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6328,18 +6328,32 @@
                             </xs:simpleContent>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element name="OutputCapacity" minOccurs="0">
-                          <xs:annotation>
-                            <xs:documentation>Output capacity of equipment.</xs:documentation>
-                          </xs:annotation>
-                          <xs:complexType>
-                            <xs:simpleContent>
-                              <xs:extension base="xs:decimal">
-                                <xs:attribute ref="auc:Source"/>
-                              </xs:extension>
-                            </xs:simpleContent>
-                          </xs:complexType>
-                        </xs:element>
+                        <xs:choice>
+                          <xs:element name="OutputCapacity" minOccurs="0">
+                            <xs:annotation>
+                              <xs:documentation>Output capacity of equipment. WARNING: This element is being deprecated, use Capacity instead</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:decimal">
+                                  <xs:attribute ref="auc:Source"/>
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="Capacity" minOccurs="0">
+                            <xs:annotation>
+                              <xs:documentation>Output capacity of equipment.</xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:decimal">
+                                  <xs:attribute ref="auc:Source"/>
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:choice>
                         <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
                         <xs:element ref="auc:HeatingStaging" minOccurs="0"/>
                         <xs:element name="NumberOfHeatingStages" minOccurs="0">

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -7601,18 +7601,32 @@
         <xs:element name="SolarThermal" minOccurs="0">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="OutputCapacity" minOccurs="0">
-                <xs:annotation>
-                  <xs:documentation>Output capacity of equipment.</xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                  <xs:simpleContent>
-                    <xs:extension base="xs:decimal">
-                      <xs:attribute ref="auc:Source"/>
-                    </xs:extension>
-                  </xs:simpleContent>
-                </xs:complexType>
-              </xs:element>
+              <xs:choice>
+                <xs:element name="OutputCapacity" minOccurs="0">
+                  <xs:annotation>
+                    <xs:documentation>Output capacity of equipment. WARNING: This element is being deprecated, use Capacity instead</xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:decimal">
+                        <xs:attribute ref="auc:Source"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="Capacity" minOccurs="0">
+                  <xs:annotation>
+                    <xs:documentation>Output capacity of equipment.</xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                    <xs:simpleContent>
+                      <xs:extension base="xs:decimal">
+                        <xs:attribute ref="auc:Source"/>
+                      </xs:extension>
+                    </xs:simpleContent>
+                  </xs:complexType>
+                </xs:element>
+              </xs:choice>
               <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
               <xs:element name="AnnualHeatingEfficiencyValue" minOccurs="0">
                 <xs:annotation>


### PR DESCRIPTION
See https://github.com/BuildingSync/TestSuite/issues/31
This change starts the deprecation of auc:OutputCapacity