### PR TITLE
Add OverallDoorToWallRatio to Building

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -778,6 +778,11 @@
           <xs:documentation>Overall window to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="OverallDoorToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+        <xs:annotation>
+          <xs:documentation>Overall door to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="HeightDistribution" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Uniformity of building height.</xs:documentation>


### PR DESCRIPTION
## Motivation
STD 211 6.2.1.2.b requires "Total area of the fenestration". BuildingSync already has OverallWindowToWallRatio, but not OverallDoorToWallRatio.