### PR TITLE
Add EIA ID to Utility

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3741,6 +3741,11 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
+      <xs:element name="EIAUtilityID" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>EIA Utility ID as found in EIA-861 and as available in OpenEI.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="UtilityName" type="xs:string" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Name of utility company billing a Resource.</xs:documentation>


### PR DESCRIPTION
## Motivation
It would be nice to have these IDs for identifying utility types: https://openei.org/wiki/List_of_United_States_Utility_Companies_and_Aliases#cite_note-1