### PR TITLE
docs(schema): add deprecation warning for Delivery Capacity

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6863,8 +6863,16 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:Capacity" minOccurs="0"/>
-                        <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
+                        <xs:element ref="auc:Capacity" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>WARNING: This element is being deprecated, use auc:Capacity of linked systems instead.</xs:documentation>
+                          </xs:annotation>
+                        </xs:element>
+                        <xs:element ref="auc:CapacityUnits" minOccurs="0">
+                          <xs:annotation>
+                            <xs:documentation>WARNING: This element is being deprecated, use auc:CapacityUnits of linked systems instead.</xs:documentation>
+                          </xs:annotation>
+                        </xs:element>
                         <xs:element ref="auc:PrimaryFuel" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>Main fuel used by the system.</xs:documentation>


### PR DESCRIPTION
Per discussion here https://github.com/BuildingSync/TestSuite/pull/37#discussion_r508725106

> It doesn't make sense to have Delivery capacity when the linked systems (fan, heating, cooling) have capacities of their own.