### PR TITLE
Correct capitalization - change `Convert to Cleaner Fuels` to `Convert to cleaner fuels`

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -4819,7 +4819,7 @@
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
                               <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
-                              <xs:enumeration value="Convert to Cleaner Fuels"/>
+                              <xs:enumeration value="Convert to cleaner fuels"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>

--- a/proposals/2021/Change Cleaner Fuels to cleaner fuels.md
+++ b/proposals/2021/Change Cleaner Fuels to cleaner fuels.md
@@ -1,0 +1,18 @@
+# Change Cleaner Fuels to cleaner fuels
+
+## Overview
+
+This proposal is to correct the format of the enumeration `Convert to Cleaner Fuels` under `BoilerPlantImprovements` measure category to `Convert to cleaner fuels`.
+
+## Justification
+
+We use sentence-like capitalization rules.
+
+## Implementation
+
+```xml
+<xs:enumeration value="Convert to cleaner fuels"/>
+```
+
+## References
+


### PR DESCRIPTION
See proposal.