### PR TITLE
Address issue using `/` with spaces

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -4895,7 +4895,8 @@
                               <xs:enumeration value="Improve distribution fans"/>
                               <xs:enumeration value="Improve ventilation fans"/>
                               <xs:enumeration value="Convert CV system to VAV system"/>
-                              <xs:enumeration value="Repair leaks / seal ducts"/>
+                              <xs:enumeration value="Repair leaks in ducts"/>
+                              <xs:enumeration value="Seal ducts"/>
                               <xs:enumeration value="Add duct insulation"/>
                               <xs:enumeration value="Balance ventilation/distribution system"/>
                               <xs:enumeration value="Repair or replace HVAC damper and controller"/>
@@ -4982,7 +4983,8 @@
                               <xs:enumeration value="Insulate thermal bypasses"/>
                               <xs:enumeration value="Increase ceiling insulation"/>
                               <xs:enumeration value="Increase roof insulation"/>
-                              <xs:enumeration value="Insulate attic hatch / stair box"/>
+                              <xs:enumeration value="Insulate attic hatch"/>
+                              <xs:enumeration value="Insulate attic stair box"/>
                               <xs:enumeration value="Add attic/knee wall insulation"/>
                               <xs:enumeration value="Install cool/green roof"/>
                               <xs:enumeration value="Add shading devices"/>

--- a/proposals/2021/Break Insulate attic hatch stair box into two.md
+++ b/proposals/2021/Break Insulate attic hatch stair box into two.md
@@ -1,4 +1,4 @@
-# Break Insulate attic hatch / stair box into two
+# Break `Insulate attic hatch / stair box` into two options
 
 ## Overview
 

--- a/proposals/2021/Break Insulate attic hatch stair box into two.md
+++ b/proposals/2021/Break Insulate attic hatch stair box into two.md
@@ -1,0 +1,23 @@
+# Break Insulate attic hatch / stair box into two
+
+## Overview
+
+This proposal is to break the `Insulate attic hatch / stair box` element into two options: `Insulate attic hatch` and `Insulate attic stair box`.  
+
+## Justification
+
+To avoid ambiguity when using `/` to connect two options.
+
+## Implementation
+
+Change
+```xml
+<xs:enumeration value="Insulate attic hatch / stair box"/>
+```
+to
+```xml
+<xs:enumeration value="Insulate attic hatch"/>
+<xs:enumeration value="Insulate attic stair box"/>
+```
+
+## References

--- a/proposals/2021/Break Repair leaks seal ducts into two.md
+++ b/proposals/2021/Break Repair leaks seal ducts into two.md
@@ -1,4 +1,4 @@
-# Break Repair leaks / seal ducts into two
+# Break `Repair leaks / seal ducts` into two options
 
 ## Overview
 

--- a/proposals/2021/Break Repair leaks seal ducts into two.md
+++ b/proposals/2021/Break Repair leaks seal ducts into two.md
@@ -1,0 +1,23 @@
+# Break Repair leaks / seal ducts into two
+
+## Overview
+
+This proposal is to break the `Repair leaks / seal ducts` element into two options: `Repair leaks in ducts` and `Seal ducts`.  
+
+## Justification
+
+To avoid ambiguity when using `/` to connect two options.
+
+## Implementation
+
+Change
+```xml
+<xs:enumeration value="Repair leaks / seal ducts"/>
+```
+to
+```xml
+<xs:enumeration value="Repair leaks in ducts"/>
+<xs:enumeration value="Seal ducts"/>
+```
+
+## References


### PR DESCRIPTION
Using `/` with spaces around to connect two phrases might cause ambiguity. Our proposal is to break the option into two to avoid using `/`. See proposal for more details.
1. 'Repair leaks / seal ducts' -> 'Repair leaks in ducts' and 'Seal ducts'
2. 'Insulate attic hatch / stair box' -> 'Insulate attic hatch' and 'Insulate attic stair box'

Resolved #332 