### PR TITLE
renamed selection tool repo to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ a new pull request with the additions.
   implemented in an uploaded instance. An API is also provided for automated integration into
   other tools. Also, the website contains an easy way to view the entirety of the schema and how elements relate to
   the [Building Exchange Data Exchange Specification](https://bedes.lbl.gov/). The Validator is open sourced 
-  [here](https://github.com/BuildingSync/selection-tool)
+  [here](https://github.com/BuildingSync/BuildingSync-website)
 * [Use Case TestSuite](https://pypi.org/project/testsuite/) provides a Python package for easier generation of BuildingSync use cases. BuildingSync use cases depend on the generation of schematron documents, which is time-consuming and difficult to implement well. The TestSuite allows users to define a use case using a more palatable CSV template, which it then turns into a Schematron document. The source code is available [here](https://github.com/BuildingSync/TestSuite).
 * [BuildingSync to OpenStudio/EnergyPlus](https://rubygems.org/gems/buildingsync). The translator is open sourced 
   [here](https://github.com/BuildingSync/BuildingSync-gem). This project will translate a Level 1 (and partial Level 2) 

--- a/docs/release_instructions.md
+++ b/docs/release_instructions.md
@@ -37,12 +37,7 @@ This should trigger a GitHub workflow for building and publishing the release. I
 
 ### Update BuildingSync Website
 
-At this point the GitHub action for publishing the release should be finished. Now we need to update the docs/data in [this repo](https://github.com/BuildingSync/selection-tool). Check out the repo and make a new branch.
+At this point the GitHub action for publishing the release should be finished. Now we need to update the docs/data in [this repo](https://github.com/BuildingSync/BuildingSync-website). Read the README in that repository.
 
-* Copy `index.html` from the release into `schema/vX.Y.Z/documentation/index.html`.
-* Copy `enumerations.json` from the release into file into a new `_data/vXXX` folder in the website folder. Note that the folder cannot contain a dot.
-* Copy the `DataDictionary.xlsx` from the release into the `schema/vXXX/datadictionary` folder.
-* Update the `datadictionary/index.html` and `measures/index.html` to point to the new `enumerations.json` file.
-* Update `/schema/index.md` to include new release by following the existing pattern.
 
-Create a Pull Request from the new branch to gh-pages.
+


### PR DESCRIPTION
#### Any background context you want to provide?
We renamed the selection-tool repository which is now part of the general BuildingSync website.

#### What does this PR do?
Renamed https://github.com/buildingsync/selection-tool to https://github.com/buildingsync/buildingsync-website

#### How should this be manually tested?
n/a

#### What are the relevant tickets?
n/a

#### Screenshots (if appropriate)
