### PR TITLE
Refactor/remove old versions

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -428,22 +428,10 @@
       </xs:sequence>
       <xs:attribute name="version" use="required">
         <xs:annotation>
-          <xs:documentation>The versions are sorted by official release date (reverse order).  Note that semantic versioning for BuildingSync was reset in 2016.  v2.0.0-legacy is the last official release of the schema before the version reset and is available in the schema repository: https://github.com/BuildingSync/schema/releases/tag/v2.0.0-legacy.  Since then, semantic versioning started at the v0.2.0 release and progresses as expected.</xs:documentation>
+          <xs:documentation>The versions are sorted by official release date (reverse order).</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:enumeration value="2.0.0-legacy"/>
-            <xs:enumeration value="0.2.0"/>
-            <xs:enumeration value="0.3.0"/>
-            <xs:enumeration value="1.0.0"/>
-            <xs:enumeration value="2.0.0-pr1"/>
-            <xs:enumeration value="2.0.0-pr2"/>
-            <xs:enumeration value="2.0.0"/>
-            <xs:enumeration value="2.1.0"/>
-            <xs:enumeration value="2.2.0-pr1"/>
-            <xs:enumeration value="2.2.0"/>
-            <xs:enumeration value="2.3.0-pr1"/>
-            <xs:enumeration value="2.3.0"/>
             <xs:enumeration value="3.0.0"/>
           </xs:restriction>
         </xs:simpleType>

--- a/examples/ASHRAE 211 Export.xml
+++ b/examples/ASHRAE 211 Export.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-9dd5d819-4587-4702-95dc-bf2775840cb6">
       <Sites>

--- a/examples/AT_example_AS_conversion_audit_report.xml
+++ b/examples/AT_example_AS_conversion_audit_report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 https://raw.githubusercontent.com/BuildingSync/schema/v2.2.0/BuildingSync.xsd" version="2.2.0">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-69928597156380">
       <auc:Sites>

--- a/examples/AT_example_NYC_audit_report_property.xml
+++ b/examples/AT_example_NYC_audit_report_property.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 https://raw.githubusercontent.com/BuildingSync/schema/v2.2.0/BuildingSync.xsd" version="2.2.0">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-69928476009540">
       <auc:Sites>

--- a/examples/AT_example_SF_audit_report.xml
+++ b/examples/AT_example_SF_audit_report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 https://raw.githubusercontent.com/BuildingSync/schema/v2.2.0/BuildingSync.xsd" version="2.2.0">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-69928597382680">
       <auc:Sites>

--- a/examples/BuildingSync Website Invalid Schema.xml
+++ b/examples/BuildingSync Website Invalid Schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-1">
       <auc:PremisesName>Example Building</auc:PremisesName>

--- a/examples/BuildingSync Website Valid Schema.xml
+++ b/examples/BuildingSync Website Valid Schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<auc:BuildingSync xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <auc:Facilities>
     <auc:Facility ID="Facility-2836a9a5-95fd-4d1d-ab8f-a852dc4cba00">
       <auc:Sites>

--- a/examples/CMS Woodlawn Campus.xml
+++ b/examples/CMS Woodlawn Campus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Programs>
     <Program>
       <ProgramDate>2008-01-01</ProgramDate>

--- a/examples/DC GSA Headquarters.xml
+++ b/examples/DC GSA Headquarters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="FirstFuel">
       <Sites>

--- a/examples/Golden Test File.xml
+++ b/examples/Golden Test File.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-be7020ff-fbdb-4901-86a8-0f868bbca12f">
       <Sites>

--- a/examples/LL87.xml
+++ b/examples/LL87.xml
@@ -2,7 +2,7 @@
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
 <!--This example file is meant to cover the majority of the functionality of New York Local Law 87-->
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-32bf1bba-967a-4a98-8843-5761d0ebd971">
       <Sites>

--- a/examples/Multi-Facility Shared Systems.xml
+++ b/examples/Multi-Facility Shared Systems.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-08f45ff8-3c5b-4169-8f27-678102e85e6b">
       <Sites>

--- a/examples/Multi_building_gbxml_externalreference_geometry.xml
+++ b/examples/Multi_building_gbxml_externalreference_geometry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-09ddd9cc-0100-4d9b-b2f5-e535f5e34743">
       <Sites>

--- a/examples/MultitenantBySubsections.xml
+++ b/examples/MultitenantBySubsections.xml
@@ -3,7 +3,7 @@
 
 <!-- "High-level" approach separating out floor areas by tenant -->
 <!-- Missing Data That We Still Want: Ownership of building -->
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-fe6dcbd1-97e9-44f2-821b-b07431b3b81c">
       <Sites>

--- a/examples/NIST Gaithersburg Campus.xml
+++ b/examples/NIST Gaithersburg Campus.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-5f583884-bad0-4c6e-b5e6-daad74ffa1d9">
       <Sites>

--- a/examples/Norfolk Federal Building.xml
+++ b/examples/Norfolk Federal Building.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-9edbe2dd-4b85-405c-bad1-dbf1613fd01d">
       <Sites>

--- a/examples/Reference Building - Primary School.xml
+++ b/examples/Reference Building - Primary School.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Audit1">
       <Sites>

--- a/examples/Richmond Federal Building.xml
+++ b/examples/Richmond Federal Building.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Facility-3ae07f5a-2ceb-4aee-b6cb-a8d83164d9e9">
       <Sites>

--- a/examples/Single_building_gbxml_externalreference_geometry.xml
+++ b/examples/Single_building_gbxml_externalreference_geometry.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This BuildingSync v3.0 document was generated from a BuildingSync v2.X document via an XML Stylesheet Language Transformation (XSLT).-->
 
-<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="2.0.0">
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../BuildingSync.xsd" version="3.0.0">
   <Facilities>
     <Facility ID="Audit1">
       <Sites>


### PR DESCRIPTION
#### What does this PR do?
Remove all `@verision` options besides `3.0.0`. A BSync document which says any other version will fail validation against the v3.0 schema

#### What are the relevant tickets?
#321 
