### PR TITLE
chore: point gbxml schemaLocation to BSync's fork

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.4.0">
-  <xs:import namespace="http://www.gbxml.org/schema" schemaLocation="https://github.com/BuildingSync/schema/releases/download/v2.3.0/GreenBuildingXML_Ver6.01.xsd"/>
+  <xs:import namespace="http://www.gbxml.org/schema" schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
   <xs:annotation>
     <xs:documentation>BuildingSync Schema - Version 2.4.0</xs:documentation>
     <xs:documentation xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
<!-- Before creating the PR make sure that the schema is formatted correctly.
  * Remove tabs (run bundle exec rake remove_tabs)
  * Ensure example files have been updated
-->

#### Any background context you want to provide?
See ticket

#### What does this PR do?
- points the schemaLocation for gbXML to our forked repo's release

#### How should this be manually tested?
N/A

#### What are the relevant tickets?
Closes #393 

#### Screenshots (if appropriate)
