### PR TITLE
refactor: allow versions without PATCH included

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -433,10 +433,15 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:enumeration value="2.0.0"/>
+            <xs:enumeration value="2.0"/>
             <xs:enumeration value="2.1.0"/>
+            <xs:enumeration value="2.1"/>
             <xs:enumeration value="2.2.0"/>
+            <xs:enumeration value="2.2"/>
             <xs:enumeration value="2.3.0"/>
+            <xs:enumeration value="2.3"/>
             <xs:enumeration value="2.4.0"/>
+            <xs:enumeration value="2.4"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:attribute>


### PR DESCRIPTION
<!-- Before creating the PR make sure that the schema is formatted correctly.
  * Remove tabs (run bundle exec rake remove_tabs)
  * Ensure example files have been updated
-->

#### Any background context you want to provide?
The root BuildingSync element has an `@version` attribute allowing users to specify the version of their document. We have been writing the full version, `MAJOR.MINOR.PATCH`, as the choices. This is not compatible with creating patch releases though -- since the `x.x.0` version was already released, it will consider any new patch version to be invalid according to that schema.

⚠️  From now on, we should _only_ add these `MAJOR.MINOR` versions!

#### What does this PR do?
- Use `MAJOR.MINOR` versions when specifying versions (but allow the old MAJOR.MINOR.PATCH to stick around)

#### How should this be manually tested?

#### What are the relevant tickets?

#414 

#### Screenshots (if appropriate)
