### PR TITLE
Deprecate Implement hot aisle hold aisle design

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -4289,7 +4289,7 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Improve data center efficiency"/>
-                              <xs:enumeration value="Implement hot aisle hold aisle design"/>
+                              <xs:enumeration value="Implement hot aisle cold aisle design"/>
                               <xs:enumeration value="Implement server virtualization"/>
                               <xs:enumeration value="Upgrade servers"/>
                               <xs:enumeration value="Clean and/or repair"/>

--- a/proposals/2021/Deprecte Implement hot aisle hold aisle design.md
+++ b/proposals/2021/Deprecte Implement hot aisle hold aisle design.md
@@ -1,0 +1,14 @@
+# Deprecate Implement hot aisle hold aisle design
+
+## Overview
+
+This proposal is the final step to fix the typo in enumeration `Implement hot aisle cold aisle design` under element `auc:DataCenterImprovements`.
+
+## Justification
+
+In version 2, the enumeration is mistakenly written as `Implement hot aisle hold aisle design`. To avoid breaking change, we add the correct enumeration in version 2.5, and now we will delete the wrong one in version 3.0.
+
+## Implementation
+Remove enumeration `Implement hot aisle hold aisle design` under element `auc:DataCenterImprovements`.
+
+## References


### PR DESCRIPTION
#### Any background context you want to provide?
This is the follow-up change to #424 

#### What does this PR do?
Remove enumeration `Implement hot aisle hold aisle design` under element `auc:DataCenterImprovements`.

#### How should this be manually tested?

#### What are the relevant tickets?
#420 
