### PR TITLE
Update ASHRAE 211 Export example v3

### DIFF
--- a/examples/ASHRAE 211 Export.xml
+++ b/examples/ASHRAE 211 Export.xml
@@ -1385,7 +1385,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n0="http://buildingsync.net/schemas/bedes-auc/2019" n0:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-c8bd32ce-2d3c-47bc-9319-d845f2d0d0ed">
@@ -1394,7 +1394,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n1="http://buildingsync.net/schemas/bedes-auc/2019" n1:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-6701d184-a286-4680-b940-3e00578dec83">
@@ -1403,7 +1403,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n2="http://buildingsync.net/schemas/bedes-auc/2019" n2:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-c98ca262-ce14-4601-bdef-65b7b829ab83">
@@ -1412,7 +1412,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n3="http://buildingsync.net/schemas/bedes-auc/2019" n3:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-be1e53ed-ebe9-4e67-919d-23fb9685c73b">
@@ -1421,7 +1421,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n4="http://buildingsync.net/schemas/bedes-auc/2019" n4:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-a60d7aa5-495c-424b-a13c-5fcdabbd7fa0">
@@ -1430,7 +1430,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n5="http://buildingsync.net/schemas/bedes-auc/2019" n5:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-c2bff83a-f1d6-4ee8-8ec8-a39b8a210eb6">
@@ -1439,7 +1439,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n6="http://buildingsync.net/schemas/bedes-auc/2019" n6:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-4f33913d-3478-49a6-817d-7a1809b38836">
@@ -1448,7 +1448,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n7="http://buildingsync.net/schemas/bedes-auc/2019" n7:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-d5988f81-ad84-4699-b15a-f5aca197ecdc">
@@ -1457,7 +1457,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n8="http://buildingsync.net/schemas/bedes-auc/2019" n8:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-18c48975-b8cd-4743-b4b7-494b73720b00">
@@ -1466,7 +1466,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n9="http://buildingsync.net/schemas/bedes-auc/2019" n9:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-69f3f722-faa6-4066-a5fd-d52e7468878d">
@@ -1475,7 +1475,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n10="http://buildingsync.net/schemas/bedes-auc/2019" n10:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-11404e7d-65c9-47dd-802d-f1bb84bde0a3">
@@ -1484,7 +1484,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n11="http://buildingsync.net/schemas/bedes-auc/2019" n11:Source="Utility">83333.3333333333</IntervalReading>
+                  <IntervalReading>83333.3333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-34f36d70-6ed0-4903-b7e8-f61f1db947b1">
@@ -1493,7 +1493,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n12="http://buildingsync.net/schemas/bedes-auc/2019" n12:Source="Utility">200</IntervalReading>
+                  <IntervalReading>200</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-a56bada5-361f-4794-ad09-eca1611c417e">
@@ -1502,7 +1502,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n13="http://buildingsync.net/schemas/bedes-auc/2019" n13:Source="Utility">225</IntervalReading>
+                  <IntervalReading>225</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-c1bbeb05-cd3e-4b83-b3fa-8a30daadaa75">
@@ -1511,7 +1511,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n14="http://buildingsync.net/schemas/bedes-auc/2019" n14:Source="Utility">240</IntervalReading>
+                  <IntervalReading>240</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-7b86e9b3-f9b5-4699-9974-7027428ced50">
@@ -1520,7 +1520,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n15="http://buildingsync.net/schemas/bedes-auc/2019" n15:Source="Utility">280</IntervalReading>
+                  <IntervalReading>280</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-1609be70-afb3-42b1-8e4f-fc6bfce8caeb">
@@ -1529,7 +1529,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n16="http://buildingsync.net/schemas/bedes-auc/2019" n16:Source="Utility">300</IntervalReading>
+                  <IntervalReading>300</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-5755363e-6e6b-4cb0-9b3c-0cbee43ed8c9">
@@ -1538,7 +1538,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n17="http://buildingsync.net/schemas/bedes-auc/2019" n17:Source="Utility">350</IntervalReading>
+                  <IntervalReading>350</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-bb0aec99-8bcf-4670-9d8e-b40233cf55be">
@@ -1547,7 +1547,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n18="http://buildingsync.net/schemas/bedes-auc/2019" n18:Source="Utility">325</IntervalReading>
+                  <IntervalReading>325</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-33f05020-1d1d-4e69-b1ce-0f958fabb65c">
@@ -1556,7 +1556,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n19="http://buildingsync.net/schemas/bedes-auc/2019" n19:Source="Utility">400</IntervalReading>
+                  <IntervalReading>400</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-b000821a-3ea7-4a8c-8bae-579880b7cac4">
@@ -1565,7 +1565,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n20="http://buildingsync.net/schemas/bedes-auc/2019" n20:Source="Utility">375</IntervalReading>
+                  <IntervalReading>375</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-1fbf116b-7d74-47ef-b88d-2f3affb34c89">
@@ -1574,7 +1574,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n21="http://buildingsync.net/schemas/bedes-auc/2019" n21:Source="Utility">300</IntervalReading>
+                  <IntervalReading>300</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-81fd0b82-2610-4114-ac16-93d8dc9a0ffb">
@@ -1583,7 +1583,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n22="http://buildingsync.net/schemas/bedes-auc/2019" n22:Source="Utility">325</IntervalReading>
+                  <IntervalReading>325</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-a8ce18b9-decb-4f91-bdf9-e7002055e94f">
@@ -1592,7 +1592,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n23="http://buildingsync.net/schemas/bedes-auc/2019" n23:Source="Utility">250</IntervalReading>
+                  <IntervalReading>250</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-f40ffa1d-abe6-4c1b-b0db-6a6f67908e22">
@@ -1601,7 +1601,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n24="http://buildingsync.net/schemas/bedes-auc/2019" n24:Source="Utility">0.560035842293907</IntervalReading>
+                  <IntervalReading>0.560035842293907</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-223d1595-52ef-448f-a898-9194618c91bd">
@@ -1610,7 +1610,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n25="http://buildingsync.net/schemas/bedes-auc/2019" n25:Source="Utility">0.551146384479718</IntervalReading>
+                  <IntervalReading>0.551146384479718</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-066fa422-4d71-46e0-b1b6-b35e4e2380e4">
@@ -1619,7 +1619,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n26="http://buildingsync.net/schemas/bedes-auc/2019" n26:Source="Utility">0.466696535244922</IntervalReading>
+                  <IntervalReading>0.466696535244922</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-2a07f968-ed23-41aa-ae27-718a149e9755">
@@ -1628,7 +1628,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n27="http://buildingsync.net/schemas/bedes-auc/2019" n27:Source="Utility">0.413359788359788</IntervalReading>
+                  <IntervalReading>0.413359788359788</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-6a949605-569b-4233-ad24-27236f32dd0b">
@@ -1637,7 +1637,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n28="http://buildingsync.net/schemas/bedes-auc/2019" n28:Source="Utility">0.373357228195938</IntervalReading>
+                  <IntervalReading>0.373357228195938</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-29674f2e-b4b4-4bc1-a7b2-719f875347f8">
@@ -1646,7 +1646,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n29="http://buildingsync.net/schemas/bedes-auc/2019" n29:Source="Utility">0.330687830687831</IntervalReading>
+                  <IntervalReading>0.330687830687831</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-0eb8c3ca-3d53-4005-806b-10f0dc276a1b">
@@ -1655,7 +1655,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n30="http://buildingsync.net/schemas/bedes-auc/2019" n30:Source="Utility">0.344637441411635</IntervalReading>
+                  <IntervalReading>0.344637441411635</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-d49606f7-e5fb-403a-b500-cbaf37448961">
@@ -1664,7 +1664,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n31="http://buildingsync.net/schemas/bedes-auc/2019" n31:Source="Utility">0.280017921146953</IntervalReading>
+                  <IntervalReading>0.280017921146953</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-504a5306-60dd-4e83-b1b2-9f4eefb1d612">
@@ -1673,7 +1673,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n32="http://buildingsync.net/schemas/bedes-auc/2019" n32:Source="Utility">0.308641975308642</IntervalReading>
+                  <IntervalReading>0.308641975308642</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-ace087ec-ca59-466c-8f6a-e03d52237962">
@@ -1682,7 +1682,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n33="http://buildingsync.net/schemas/bedes-auc/2019" n33:Source="Utility">0.373357228195938</IntervalReading>
+                  <IntervalReading>0.373357228195938</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-533b0082-eacf-4c0e-b79d-53200739be87">
@@ -1691,7 +1691,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n34="http://buildingsync.net/schemas/bedes-auc/2019" n34:Source="Utility">0.356125356125356</IntervalReading>
+                  <IntervalReading>0.356125356125356</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-6a0a974d-fde2-4349-b1a1-38062dfa521f">
@@ -1700,7 +1700,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n35="http://buildingsync.net/schemas/bedes-auc/2019" n35:Source="Utility">0.448028673835125</IntervalReading>
+                  <IntervalReading>0.448028673835125</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-b2b25519-b828-49c8-bca6-4d51dc072428">
@@ -1709,7 +1709,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n36="http://buildingsync.net/schemas/bedes-auc/2019" n36:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-764f9d47-fd9f-4cf4-8bca-ba273b343c35">
@@ -1718,7 +1718,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n37="http://buildingsync.net/schemas/bedes-auc/2019" n37:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-402fa488-478f-45cb-9561-e38bcad0037e">
@@ -1727,7 +1727,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n38="http://buildingsync.net/schemas/bedes-auc/2019" n38:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-c4c6cdf2-d107-4452-a8a0-e4d725d4cbbe">
@@ -1736,7 +1736,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n39="http://buildingsync.net/schemas/bedes-auc/2019" n39:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-45284725-5e31-4044-8d3b-c1f63e0594b6">
@@ -1745,7 +1745,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n40="http://buildingsync.net/schemas/bedes-auc/2019" n40:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-db8361d9-6bb1-4e61-b2a8-7a61ac3b202e">
@@ -1754,7 +1754,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n41="http://buildingsync.net/schemas/bedes-auc/2019" n41:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-da747891-072e-4e56-9061-e0716536cf8f">
@@ -1763,7 +1763,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n42="http://buildingsync.net/schemas/bedes-auc/2019" n42:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-af8dbd5c-6965-45c4-bb08-50422b0c61f9">
@@ -1772,7 +1772,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n43="http://buildingsync.net/schemas/bedes-auc/2019" n43:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-2a2c921c-93c9-4e6f-a3a8-e7cfb5b3519b">
@@ -1781,7 +1781,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n44="http://buildingsync.net/schemas/bedes-auc/2019" n44:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-eab9c1d1-0e61-42a0-b422-d5e3a4a6c6f3">
@@ -1790,7 +1790,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n45="http://buildingsync.net/schemas/bedes-auc/2019" n45:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-869645d8-4bfb-45b9-b077-f0a0d96e9280">
@@ -1799,7 +1799,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n46="http://buildingsync.net/schemas/bedes-auc/2019" n46:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-4861a811-4c23-4451-9676-78005adb10a7">
@@ -1808,7 +1808,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n47="http://buildingsync.net/schemas/bedes-auc/2019" n47:Source="Utility">8333.33333333333</IntervalReading>
+                  <IntervalReading>8333.33333333333</IntervalReading>
                   <ResourceUseID IDref="Resource1"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-6dc61cef-4a32-4e07-8875-cc8f5f124fe9">
@@ -1817,7 +1817,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n48="http://buildingsync.net/schemas/bedes-auc/2019" n48:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-23265f11-4f23-4446-9af5-0b9cf199af10">
@@ -1826,7 +1826,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n49="http://buildingsync.net/schemas/bedes-auc/2019" n49:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-23d08d2a-f74c-4218-9af1-ad3e68606210">
@@ -1835,7 +1835,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n50="http://buildingsync.net/schemas/bedes-auc/2019" n50:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-17a9791c-f3e4-4c40-adb0-c0a4429f5603">
@@ -1844,7 +1844,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n51="http://buildingsync.net/schemas/bedes-auc/2019" n51:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-6a47d9f7-def2-47b0-a904-83a4573407ce">
@@ -1853,7 +1853,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n52="http://buildingsync.net/schemas/bedes-auc/2019" n52:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-84d463c8-3d50-4134-b186-998d21f5dfd1">
@@ -1862,7 +1862,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n53="http://buildingsync.net/schemas/bedes-auc/2019" n53:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-d4f3a195-1632-4f8b-bbb8-149d14b65875">
@@ -1871,7 +1871,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n54="http://buildingsync.net/schemas/bedes-auc/2019" n54:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-bcc1da68-b3a8-48f7-a6ec-4f44da5700c0">
@@ -1880,7 +1880,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n55="http://buildingsync.net/schemas/bedes-auc/2019" n55:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-3c77cba2-72a4-4d0d-9c3b-413463e1953f">
@@ -1889,7 +1889,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n56="http://buildingsync.net/schemas/bedes-auc/2019" n56:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-2e077499-37eb-41e2-880d-c50141fddae8">
@@ -1898,7 +1898,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n57="http://buildingsync.net/schemas/bedes-auc/2019" n57:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-a750bdeb-12e0-4ed8-9e40-f091cb456c2f">
@@ -1907,7 +1907,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n58="http://buildingsync.net/schemas/bedes-auc/2019" n58:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-cf4cda58-aec4-42b4-9a7e-9390fc74d35e">
@@ -1916,7 +1916,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n59="http://buildingsync.net/schemas/bedes-auc/2019" n59:Source="Utility">2145</IntervalReading>
+                  <IntervalReading>2145</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-5e0d9630-977a-42be-95e3-17bd96a37aca">
@@ -1925,7 +1925,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n60="http://buildingsync.net/schemas/bedes-auc/2019" n60:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-db6ee074-f69e-42f4-87a1-1dae468cb986">
@@ -1934,7 +1934,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n61="http://buildingsync.net/schemas/bedes-auc/2019" n61:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-02755afc-4a82-46fc-906a-c7bb59d95d83">
@@ -1943,7 +1943,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n62="http://buildingsync.net/schemas/bedes-auc/2019" n62:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-8aaa738e-d825-4e5f-97b7-0033508b1aeb">
@@ -1952,7 +1952,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n63="http://buildingsync.net/schemas/bedes-auc/2019" n63:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-18f67336-da42-43dd-996f-e3993dda10a7">
@@ -1961,7 +1961,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n64="http://buildingsync.net/schemas/bedes-auc/2019" n64:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-1e3bf9ec-153d-4a6e-a219-2d3ec79f8698">
@@ -1970,7 +1970,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n65="http://buildingsync.net/schemas/bedes-auc/2019" n65:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-e600aa84-0533-4589-b347-9bccc24e0b7d">
@@ -1979,7 +1979,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n66="http://buildingsync.net/schemas/bedes-auc/2019" n66:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-d610c9df-a5ab-45d8-badc-2cee19984fce">
@@ -1988,7 +1988,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n67="http://buildingsync.net/schemas/bedes-auc/2019" n67:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-22743832-86fc-4787-b587-a1f35da0d2be">
@@ -1997,7 +1997,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n68="http://buildingsync.net/schemas/bedes-auc/2019" n68:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-1b0e3ab1-0c12-4ee7-9682-bce3f04cda5f">
@@ -2006,7 +2006,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n69="http://buildingsync.net/schemas/bedes-auc/2019" n69:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-e3d3eb43-58fc-44aa-bcfe-88a8e210e8fb">
@@ -2015,7 +2015,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n70="http://buildingsync.net/schemas/bedes-auc/2019" n70:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-35c4a24c-bbb4-4b3a-991d-b9ad91a2a6c1">
@@ -2024,7 +2024,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n71="http://buildingsync.net/schemas/bedes-auc/2019" n71:Source="Utility">1608.75</IntervalReading>
+                  <IntervalReading>1608.75</IntervalReading>
                   <ResourceUseID IDref="Resource2"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-23b8871f-bac2-48df-82cf-1c1bbbbfda5f">
@@ -2033,7 +2033,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n72="http://buildingsync.net/schemas/bedes-auc/2019" n72:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-c2d3b831-1b20-463c-9e20-e28613ba7ac3">
@@ -2042,7 +2042,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n73="http://buildingsync.net/schemas/bedes-auc/2019" n73:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-95dda259-c02b-4b83-9bac-20506a676b9c">
@@ -2051,7 +2051,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n74="http://buildingsync.net/schemas/bedes-auc/2019" n74:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-0c4a42a4-e70d-4926-ba44-30e7261ab575">
@@ -2060,7 +2060,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n75="http://buildingsync.net/schemas/bedes-auc/2019" n75:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-eaa20a88-51f7-498d-ad3f-8ebc01b692d3">
@@ -2069,7 +2069,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n76="http://buildingsync.net/schemas/bedes-auc/2019" n76:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-065147e4-79ed-4595-94b6-32c664bae4a7">
@@ -2078,7 +2078,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n77="http://buildingsync.net/schemas/bedes-auc/2019" n77:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-73935d42-c040-483b-be81-9c33d3ef420c">
@@ -2087,7 +2087,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n78="http://buildingsync.net/schemas/bedes-auc/2019" n78:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-db953a74-5e5b-44d6-a01c-6297828e5eaa">
@@ -2096,7 +2096,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n79="http://buildingsync.net/schemas/bedes-auc/2019" n79:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-11abe7a3-e5f5-4bf1-869d-330dadc4eec7">
@@ -2105,7 +2105,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n80="http://buildingsync.net/schemas/bedes-auc/2019" n80:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-f83bc3a8-b0af-4f25-afdc-f9a2c3a2f4d6">
@@ -2114,7 +2114,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n81="http://buildingsync.net/schemas/bedes-auc/2019" n81:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-a91e0bdf-f882-4268-bea6-63a2addab4b9">
@@ -2123,7 +2123,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n82="http://buildingsync.net/schemas/bedes-auc/2019" n82:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-b8f83db1-510f-4733-af9a-409080c26924">
@@ -2132,7 +2132,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n83="http://buildingsync.net/schemas/bedes-auc/2019" n83:Source="Utility">12375</IntervalReading>
+                  <IntervalReading>12375</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-991bdf2d-be32-4d50-aa81-41e00e334382">
@@ -2141,7 +2141,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n84="http://buildingsync.net/schemas/bedes-auc/2019" n84:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-fc11bb8a-57fd-45ea-8ef7-cc931a437dd0">
@@ -2150,7 +2150,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n85="http://buildingsync.net/schemas/bedes-auc/2019" n85:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-5a253839-e634-4c3a-a5db-a2d7823cfece">
@@ -2159,7 +2159,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n86="http://buildingsync.net/schemas/bedes-auc/2019" n86:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-6907e3a1-d853-4eee-b342-b70785e25e1a">
@@ -2168,7 +2168,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n87="http://buildingsync.net/schemas/bedes-auc/2019" n87:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-67ebc056-6183-496d-a0f0-7a5ce2b78de8">
@@ -2177,7 +2177,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n88="http://buildingsync.net/schemas/bedes-auc/2019" n88:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-e39389ad-2f3a-4731-878f-3f2876427781">
@@ -2186,7 +2186,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n89="http://buildingsync.net/schemas/bedes-auc/2019" n89:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-88c9a3c7-7d2c-4284-b96d-1fc067aea11c">
@@ -2195,7 +2195,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n90="http://buildingsync.net/schemas/bedes-auc/2019" n90:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-3ec2b560-1876-4365-844e-9746a3c27300">
@@ -2204,7 +2204,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n91="http://buildingsync.net/schemas/bedes-auc/2019" n91:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-bb8a7aa8-23ae-4f4b-8261-17b39014df66">
@@ -2213,7 +2213,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n92="http://buildingsync.net/schemas/bedes-auc/2019" n92:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-27a92a1c-68ed-44ec-8743-a295c3c37ea0">
@@ -2222,7 +2222,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n93="http://buildingsync.net/schemas/bedes-auc/2019" n93:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-1e917b7c-a3c5-4530-bf9f-93396f103ac2">
@@ -2231,7 +2231,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n94="http://buildingsync.net/schemas/bedes-auc/2019" n94:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-4ffd11e1-15bc-4fa8-85b0-8e2e54b3f0af">
@@ -2240,7 +2240,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n95="http://buildingsync.net/schemas/bedes-auc/2019" n95:Source="Utility">2970</IntervalReading>
+                  <IntervalReading>2970</IntervalReading>
                   <ResourceUseID IDref="Resource3"/>
                 </TimeSeries>
                 <TimeSeries ID="TimeSeries-1fbe38d5-9cf7-4cdc-a659-0db2505c7395">
@@ -2249,7 +2249,7 @@
                   <StartTimestamp>2010-01-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-02-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n96="http://buildingsync.net/schemas/bedes-auc/2019" n96:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2263,7 +2263,7 @@
                   <StartTimestamp>2010-02-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-03-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n97="http://buildingsync.net/schemas/bedes-auc/2019" n97:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2277,7 +2277,7 @@
                   <StartTimestamp>2010-03-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-04-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n98="http://buildingsync.net/schemas/bedes-auc/2019" n98:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2291,7 +2291,7 @@
                   <StartTimestamp>2010-04-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-05-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n99="http://buildingsync.net/schemas/bedes-auc/2019" n99:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2305,7 +2305,7 @@
                   <StartTimestamp>2010-05-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-06-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n100="http://buildingsync.net/schemas/bedes-auc/2019" n100:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2319,7 +2319,7 @@
                   <StartTimestamp>2010-06-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-07-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n101="http://buildingsync.net/schemas/bedes-auc/2019" n101:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2333,7 +2333,7 @@
                   <StartTimestamp>2010-07-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-08-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n102="http://buildingsync.net/schemas/bedes-auc/2019" n102:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2347,7 +2347,7 @@
                   <StartTimestamp>2010-08-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-09-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n103="http://buildingsync.net/schemas/bedes-auc/2019" n103:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2361,7 +2361,7 @@
                   <StartTimestamp>2010-09-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-10-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n104="http://buildingsync.net/schemas/bedes-auc/2019" n104:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2375,7 +2375,7 @@
                   <StartTimestamp>2010-10-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-11-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n105="http://buildingsync.net/schemas/bedes-auc/2019" n105:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2389,7 +2389,7 @@
                   <StartTimestamp>2010-11-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2010-12-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n106="http://buildingsync.net/schemas/bedes-auc/2019" n106:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>
@@ -2403,7 +2403,7 @@
                   <StartTimestamp>2010-12-02T00:00:00</StartTimestamp>
                   <EndTimestamp>2011-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
-                  <IntervalReading xmlns:n107="http://buildingsync.net/schemas/bedes-auc/2019" n107:Source="Utility">12912.0833333333</IntervalReading>
+                  <IntervalReading>12912.0833333333</IntervalReading>
                   <UserDefinedFields>
                     <UserDefinedField>
                       <FieldName>Time Series Description</FieldName>


### PR DESCRIPTION
#### Any background context you want to provide?
The ASHRAE 211 Export example file has the redundant `xmlns` and `nX:source` attributes in the interval reading elements. These should be removed to ease readability.

#### What does this PR do?
Remove the `xmlns` and `nX:source` attributes in the interval reading elements for v3 branch

#### What are the relevant tickets?
#427 
