### PR TITLE
Deprecate MORE in eGRIDSubregionCode

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -14544,7 +14544,6 @@
               <xs:enumeration value="FRCC"/>
               <xs:enumeration value="HIMS"/>
               <xs:enumeration value="HIOA"/>
-              <xs:enumeration value="MORE"/>
               <xs:enumeration value="MROE"/>
               <xs:enumeration value="MROW"/>
               <xs:enumeration value="NEWE"/>


### PR DESCRIPTION
#### Any background context you want to provide?
eGRID region code `MROE` was spelled incorrectly as `MORE` and this bug was fixed through #279 (adding the correct code) and #342 (deprecating the incorrect one in version 3.0). However the incorrect option was brought back while we refactor `eGRIDSubregionCode` in #387. We need to deprecate `MORE` again in version 3.0.

#### What does this PR do?
Remove `MORE` under `eGRIDSubregionCode`.

#### What are the relevant tickets?
#431 
