### PR TITLE
Schema modifications for CO2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ geojson.xsd
 .venv
 *.egg-info
 .ipynb_checkpoints
+*.bak

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -15558,17 +15558,10 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="ActiveDehumidification">
+  <xs:element name="ActiveDehumidification" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>True if an active dehumidification system is available (in addition to the dehumidification that takes place during normal direct expansion (DX) cooling operation).</xs:documentation>
     </xs:annotation>
-    <xs:complexType>
-      <xs:simpleContent>
-        <xs:extension base="xs:decimal">
-          <xs:attribute ref="auc:Source"/>
-        </xs:extension>
-      </xs:simpleContent>
-    </xs:complexType>
   </xs:element>
   <xs:element name="AnnualCoolingEfficiencyValue">
     <xs:annotation>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3416,8 +3416,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
-      <xs:element minOccurs="0" name="AnnualAverageGHGEmissions">
+      <xs:element name="AnnualAverageGHGEmissions" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Annual Average GHG Emissions. (MtCO2e)</xs:documentation>
         </xs:annotation>
@@ -3453,6 +3452,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
+      <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="ID" type="xs:ID" use="required"/>
   </xs:complexType>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019"
-  xmlns:gbxml="http://www.gbxml.org/schema"
-  targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified"
-  attributeFormDefault="unqualified" version="2.4.0">
-  <xs:import namespace="http://www.gbxml.org/schema"
-    schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.4.0">
+  <xs:import namespace="http://www.gbxml.org/schema" schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
   <xs:annotation>
     <xs:documentation>BuildingSync Schema - Version 2.4.0</xs:documentation>
     <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -85,178 +80,154 @@
                           <xs:element name="HVACSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HVACSystem" type="auc:HVACSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="HVACSystem" type="auc:HVACSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LightingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LightingSystem" type="auc:LightingSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="LightingSystem" type="auc:LightingSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DomesticHotWaterSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DomesticHotWaterSystem"
-                                  type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="DomesticHotWaterSystem" type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CookingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CookingSystem" type="auc:CookingSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="CookingSystem" type="auc:CookingSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RefrigerationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RefrigerationSystem"
-                                  type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="RefrigerationSystem" type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DishwasherSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LaundrySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PumpSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PumpSystem" type="auc:PumpSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="PumpSystem" type="auc:PumpSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FanSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FanSystem" type="auc:FanSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="FanSystem" type="auc:FanSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="MotorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="MotorSystem" type="auc:MotorSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="MotorSystem" type="auc:MotorSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="HeatRecoverySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HeatRecoverySystem"
-                                  type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
+                                <xs:element name="HeatRecoverySystem" type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="WallSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WallSystem" type="auc:WallSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="WallSystem" type="auc:WallSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RoofSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RoofSystem" type="auc:RoofSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="RoofSystem" type="auc:RoofSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CeilingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FenestrationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FenestrationSystem"
-                                  type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FenestrationSystem" type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ExteriorFloorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ExteriorFloorSystem"
-                                  type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="ExteriorFloorSystem" type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FoundationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CriticalITSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PlugLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ProcessLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ConveyanceSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="OnsiteStorageTransmissionGenerationSystems"
-                            minOccurs="0">
+                          <xs:element name="OnsiteStorageTransmissionGenerationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="OnsiteStorageTransmissionGenerationSystem"
-                                  type="auc:OnsiteStorageTransmissionGenerationSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="OnsiteStorageTransmissionGenerationSystem" type="auc:OnsiteStorageTransmissionGenerationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -270,8 +241,7 @@
                           <xs:element name="WaterUses" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WaterUse" type="auc:WaterUseType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="WaterUse" type="auc:WaterUseType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -284,14 +254,12 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="AirInfiltrationNotes" type="xs:string"
-                                        minOccurs="0">
+                                      <xs:element name="AirInfiltrationNotes" type="xs:string" minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="Tightness" type="auc:Tightness"
-                                        minOccurs="0">
+                                      <xs:element name="Tightness" type="auc:Tightness" minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Description of the infiltration characteristics for an opaque surface, fenestration unit, a thermal zone.</xs:documentation>
                                         </xs:annotation>
@@ -356,19 +324,15 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="WaterInfiltrationNotes" type="xs:string"
-                                        minOccurs="0">
+                                      <xs:element name="WaterInfiltrationNotes" type="xs:string" minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages"
-                                        minOccurs="0">
+                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages" minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element
-                                              name="LocationsOfExteriorWaterIntrusionDamage"
-                                              minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="LocationsOfExteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the outside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -388,13 +352,10 @@
                                           </xs:sequence>
                                         </xs:complexType>
                                       </xs:element>
-                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages"
-                                        minOccurs="0">
+                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages" minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element
-                                              name="LocationsOfInteriorWaterIntrusionDamage"
-                                              minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="LocationsOfInteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the inside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -424,8 +385,7 @@
                     <xs:element name="Schedules" minOccurs="0">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"
-                          />
+                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"/>
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
@@ -763,14 +723,12 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="OverallWindowToWallRatio" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallWindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall window to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="OverallDoorToWallRatio" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallDoorToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall door to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -830,10 +788,8 @@
                         <xs:enumeration value="ENERGY STAR"/>
                         <xs:enumeration value="ENERGY STAR Certified Homes"/>
                         <xs:enumeration value="LEED"/>
-                        <xs:enumeration
-                          value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
-                        <xs:enumeration
-                          value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
+                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
+                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
                         <xs:enumeration value="Passive House"/>
                         <xs:enumeration value="Living Building Challenge"/>
                         <xs:enumeration value="Green Globes"/>
@@ -1126,8 +1082,7 @@
                                 <xs:element name="WallIDs">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WallID" minOccurs="0"
-                                        maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WallID" minOccurs="0" maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1137,8 +1092,7 @@
                                 <xs:element name="WindowIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WindowID" minOccurs="0"
-                                        maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WindowID" minOccurs="0" maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1148,8 +1102,7 @@
                                 <xs:element name="DoorIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:DoorID" minOccurs="0"
-                                        maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:DoorID" minOccurs="0" maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1203,8 +1156,7 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition"
-                                      minOccurs="0">
+                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Description of the roof's condition.</xs:documentation>
                                       </xs:annotation>
@@ -1215,8 +1167,7 @@
                                       </xs:annotation>
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="SkylightID" minOccurs="0"
-                                            maxOccurs="unbounded">
+                                          <xs:element name="SkylightID" minOccurs="0" maxOccurs="unbounded">
                                             <xs:annotation>
                                               <xs:documentation>ID number of the skylight type associated with this side of the section.</xs:documentation>
                                             </xs:annotation>
@@ -1224,19 +1175,18 @@
                                               <xs:sequence>
                                                 <xs:element name="PercentSkylightArea" minOccurs="0">
                                                   <xs:annotation>
-                                                  <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
+                                                    <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
                                                   </xs:annotation>
                                                   <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:decimal">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
+                                                    <xs:simpleContent>
+                                                      <xs:extension base="xs:decimal">
+                                                        <xs:attribute ref="auc:Source"/>
+                                                      </xs:extension>
+                                                    </xs:simpleContent>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
-                                              <xs:attribute name="IDref" type="xs:IDREF"
-                                                use="required"/>
+                                              <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                                             </xs:complexType>
                                           </xs:element>
                                         </xs:sequence>
@@ -1471,8 +1421,7 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ThermalZone" type="auc:ThermalZoneType"
-                          maxOccurs="unbounded"/>
+                        <xs:element name="ThermalZone" type="auc:ThermalZoneType" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
@@ -2100,8 +2049,7 @@
                         <xs:element name="StandardPractice" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="StandardPracticeDescription" type="xs:string"
-                                minOccurs="0">
+                              <xs:element name="StandardPracticeDescription" type="xs:string" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the standard practice represented by this scenario (e.g., builder standard practice, portfolio average, local practice).</xs:documentation>
                                 </xs:annotation>
@@ -2113,8 +2061,7 @@
                         <xs:element name="Other" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="OtherBenchmarkDescription" type="xs:string"
-                                minOccurs="0">
+                              <xs:element name="OtherBenchmarkDescription" type="xs:string" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the benchmark scenario (e.g., original design, building next door).</xs:documentation>
                                 </xs:annotation>
@@ -2226,8 +2173,7 @@
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(d)</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh"
-                          minOccurs="0">
+                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(e)</xs:documentation>
                           </xs:annotation>
@@ -2455,8 +2401,7 @@
       <xs:element name="AllResourceTotals" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType"
-              maxOccurs="unbounded"/>
+            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -2526,22 +2471,16 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0"
-                                      maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
                                           <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                          <xs:element ref="auc:DemandRatchetPercentage"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
                                           <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
                                           <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
                                           <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
@@ -2565,69 +2504,52 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0"
-                                      maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
                                           <xs:element name="TimeOfUsePeriods" minOccurs="0">
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="TimeOfUsePeriod" minOccurs="0"
-                                                  maxOccurs="unbounded">
+                                                <xs:element name="TimeOfUsePeriod" minOccurs="0" maxOccurs="unbounded">
                                                   <xs:complexType>
-                                                  <xs:sequence>
-                                                  <xs:element name="TOUNumberForRateStructure"
-                                                  type="xs:int" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The number associated with the TOU period.</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element
-                                                  name="ApplicableStartTimeForEnergyRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element name="ApplicableEndTimeForEnergyRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element
-                                                  name="ApplicableStartTimeForDemandRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element name="ApplicableEndTimeForDemandRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                  <xs:element ref="auc:ElectricDemandRate"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:EnergyRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRatchetPercentage"
-                                                  minOccurs="0"/>
-                                                  </xs:sequence>
+                                                    <xs:sequence>
+                                                      <xs:element name="TOUNumberForRateStructure" type="xs:int" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The number associated with the TOU period.</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableStartTimeForEnergyRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableEndTimeForEnergyRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableStartTimeForDemandRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableEndTimeForDemandRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                      <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
+                                                      <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
+                                                      <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
+                                                      <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                      <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
+                                                    </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
@@ -2655,80 +2577,66 @@
                                     <xs:element name="RatePeriods" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatePeriod" minOccurs="0"
-                                            maxOccurs="unbounded">
+                                          <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                               <xs:sequence>
                                                 <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                                <xs:element
-                                                  ref="auc:ApplicableStartDateForEnergyRate"
-                                                  minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate"
-                                                  minOccurs="0"/>
-                                                <xs:element
-                                                  ref="auc:ApplicableStartDateForDemandRate"
-                                                  minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForDemandRate"
-                                                  minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
                                                 <xs:element name="RateTiers" minOccurs="0">
                                                   <xs:complexType>
-                                                  <xs:sequence>
-                                                  <xs:element name="RateTier" minOccurs="0"
-                                                  maxOccurs="unbounded">
-                                                  <xs:complexType>
-                                                  <xs:sequence>
-                                                  <xs:element
-                                                  name="ConsumptionEnergyTierDesignation"
-                                                  minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:integer">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element name="MaxkWhUsage" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:decimal">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element name="MaxkWUsage" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:decimal">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                  <xs:element ref="auc:ElectricDemandRate"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:EnergyRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRatchetPercentage"
-                                                  minOccurs="0"/>
-                                                  </xs:sequence>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  </xs:sequence>
+                                                    <xs:sequence>
+                                                      <xs:element name="RateTier" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                          <xs:sequence>
+                                                            <xs:element name="ConsumptionEnergyTierDesignation" minOccurs="0">
+                                                            <xs:annotation>
+                                                            <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
+                                                            </xs:annotation>
+                                                            <xs:complexType>
+                                                            <xs:simpleContent>
+                                                            <xs:extension base="xs:integer">
+                                                            <xs:attribute ref="auc:Source"/>
+                                                            </xs:extension>
+                                                            </xs:simpleContent>
+                                                            </xs:complexType>
+                                                            </xs:element>
+                                                            <xs:element name="MaxkWhUsage" minOccurs="0">
+                                                            <xs:annotation>
+                                                            <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
+                                                            </xs:annotation>
+                                                            <xs:complexType>
+                                                            <xs:simpleContent>
+                                                            <xs:extension base="xs:decimal">
+                                                            <xs:attribute ref="auc:Source"/>
+                                                            </xs:extension>
+                                                            </xs:simpleContent>
+                                                            </xs:complexType>
+                                                            </xs:element>
+                                                            <xs:element name="MaxkWUsage" minOccurs="0">
+                                                            <xs:annotation>
+                                                            <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
+                                                            </xs:annotation>
+                                                            <xs:complexType>
+                                                            <xs:simpleContent>
+                                                            <xs:extension base="xs:decimal">
+                                                            <xs:attribute ref="auc:Source"/>
+                                                            </xs:extension>
+                                                            </xs:simpleContent>
+                                                            </xs:complexType>
+                                                            </xs:element>
+                                                            <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                            <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
+                                                            <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
+                                                            <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
+                                                            <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                            <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
+                                                          </xs:sequence>
+                                                        </xs:complexType>
+                                                      </xs:element>
+                                                    </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                                 <xs:element ref="auc:EnergySellRate" minOccurs="0"/>
@@ -3242,8 +3150,7 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="1"
-                          name="EmissionsLinkedTimeSeriesID">
+                        <xs:element maxOccurs="unbounded" minOccurs="1" name="EmissionsLinkedTimeSeriesID">
                           <xs:complexType>
                             <xs:attribute name="IDref" type="xs:IDREF"/>
                           </xs:complexType>
@@ -3746,8 +3653,7 @@
                   <xs:element name="Replacement" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemReplaced" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemReplaced" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems replaced by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3755,8 +3661,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element name="AlternativeSystemReplacement" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemReplacement" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would replace the existing systems.</xs:documentation>
                           </xs:annotation>
@@ -3764,8 +3669,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3779,8 +3683,7 @@
                   <xs:element name="ModificationRetrocommissioning" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemAffected" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemAffected" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems affected by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3796,8 +3699,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3811,8 +3713,7 @@
                   <xs:element name="Addition" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="AlternativeSystemAdded" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemAdded" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would be added as part of the measure.</xs:documentation>
                           </xs:annotation>
@@ -3820,8 +3721,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3843,8 +3743,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3923,8 +3822,7 @@
                               <xs:enumeration value="Convert system from steam to hot water"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Convert to Cleaner Fuels"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -3953,8 +3851,7 @@
                               <xs:enumeration value="Add or replace cooling tower"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3978,8 +3875,7 @@
                               <xs:enumeration value="Add or upgrade BAS/EMS/EMCS"/>
                               <xs:enumeration value="Add or upgrade controls"/>
                               <xs:enumeration value="Convert pneumatic controls to DDC"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4011,8 +3907,7 @@
                               <xs:enumeration value="Replace package units"/>
                               <xs:enumeration value="Replace packaged terminal units"/>
                               <xs:enumeration value="Install passive solar heating"/>
-                              <xs:enumeration
-                                value="Replace AC and heating units with ground coupled heat pump systems"/>
+                              <xs:enumeration value="Replace AC and heating units with ground coupled heat pump systems"/>
                               <xs:enumeration value="Add enhanced dehumidification"/>
                               <xs:enumeration value="Install solar ventilation preheating system"/>
                               <xs:enumeration value="Add or repair economizer"/>
@@ -4027,8 +3922,7 @@
                               <xs:enumeration value="Install or Upgrade Master Venting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other heating"/>
                               <xs:enumeration value="Other cooling"/>
                               <xs:enumeration value="Other ventilation"/>
@@ -4056,10 +3950,8 @@
                               <xs:enumeration value="Retrofit with T-5"/>
                               <xs:enumeration value="Retrofit with T-8"/>
                               <xs:enumeration value="Install spectrally enhanced lighting"/>
-                              <xs:enumeration
-                                value="Retrofit with fiber optic lighting technologies"/>
-                              <xs:enumeration
-                                value="Retrofit with light emitting diode technologies"/>
+                              <xs:enumeration value="Retrofit with fiber optic lighting technologies"/>
+                              <xs:enumeration value="Retrofit with light emitting diode technologies"/>
                               <xs:enumeration value="Add daylight controls"/>
                               <xs:enumeration value="Add occupancy sensors"/>
                               <xs:enumeration value="Install photocell control"/>
@@ -4069,8 +3961,7 @@
                               <xs:enumeration value="Upgrade exterior lighting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4128,10 +4019,8 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Add pipe insulation"/>
                               <xs:enumeration value="Repair and/or replace steam traps"/>
-                              <xs:enumeration
-                                value="Retrofit and replace chiller plant pumping, piping, and controls"/>
-                              <xs:enumeration
-                                value="Repair or replace existing condensate return systems or install new condensate return systems"/>
+                              <xs:enumeration value="Retrofit and replace chiller plant pumping, piping, and controls"/>
+                              <xs:enumeration value="Repair or replace existing condensate return systems or install new condensate return systems"/>
                               <xs:enumeration value="Add recirculating pumps"/>
                               <xs:enumeration value="Replace or upgrade water heater"/>
                               <xs:enumeration value="Add energy recovery"/>
@@ -4144,8 +4033,7 @@
                               <xs:enumeration value="Install steam condensate heat recovery"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4170,8 +4058,7 @@
                               <xs:enumeration value="Upgrade motors"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4196,8 +4083,7 @@
                               <xs:enumeration value="Add VSD motor controller"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4217,14 +4103,12 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration
-                                value="Replace ice/refrigeration equipment with high efficiency units"/>
+                              <xs:enumeration value="Replace ice/refrigeration equipment with high efficiency units"/>
                               <xs:enumeration value="Replace air-cooled ice/refrigeration equipment"/>
                               <xs:enumeration value="Replace refrigerators"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4250,8 +4134,7 @@
                               <xs:enumeration value="Convert fuels"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4271,17 +4154,14 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration
-                                value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
+                              <xs:enumeration value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
                               <xs:enumeration value="Install photovoltaic system"/>
                               <xs:enumeration value="Install wind energy system"/>
-                              <xs:enumeration
-                                value="Install wood waste or other organic waste stream heating or power plant"/>
+                              <xs:enumeration value="Install wood waste or other organic waste stream heating or power plant"/>
                               <xs:enumeration value="Install electrical storage"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4307,8 +4187,7 @@
                               <xs:enumeration value="Install gas distribution systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4342,8 +4221,7 @@
                               <xs:enumeration value="Install tankless water heaters"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4369,8 +4247,7 @@
                               <xs:enumeration value="Implement water efficient irrigation"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4392,8 +4269,7 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Install thermal energy storage"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4414,10 +4290,8 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Change to more favorable rate schedule"/>
-                              <xs:enumeration
-                                value="Energy cost reduction through rate adjustments - uncategorized"/>
-                              <xs:enumeration
-                                value="Energy service billing and meter auditing recommendations"/>
+                              <xs:enumeration value="Energy cost reduction through rate adjustments - uncategorized"/>
+                              <xs:enumeration value="Energy service billing and meter auditing recommendations"/>
                               <xs:enumeration value="Change to lower energy cost supplier(s)"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -4439,12 +4313,10 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Implement industrial process improvements"/>
-                              <xs:enumeration
-                                value="Implement production and/or manufacturing improvements"/>
+                              <xs:enumeration value="Implement production and/or manufacturing improvements"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4467,8 +4339,7 @@
                               <xs:enumeration value="Install advanced metering systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4496,8 +4367,7 @@
                               <xs:enumeration value="Replace washing machines"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4524,8 +4394,7 @@
                               <xs:enumeration value="Upgrade servers"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -5005,8 +4874,7 @@
               </xs:annotation>
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType"
-                    minOccurs="0">
+                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Qualification of auditor responsible for the audit report.</xs:documentation>
                     </xs:annotation>
@@ -5034,8 +4902,7 @@
                       <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="AuditTeamMemberCertificationType"
-                    type="auc:AuditorQualificationType" minOccurs="0">
+                  <xs:element name="AuditTeamMemberCertificationType" type="auc:AuditorQualificationType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Type of certification held by an auditor team member.</xs:documentation>
                     </xs:annotation>
@@ -5106,8 +4973,7 @@
             <xs:element name="HeatingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0"
-                    maxOccurs="unbounded">
+                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of central heating system, defined as any source of heating energy separate from the zone being heated. Local heating systems (such as packaged systems and fan-coils) are recorded in a separate data field.</xs:documentation>
                     </xs:annotation>
@@ -5118,8 +4984,7 @@
             <xs:element name="CoolingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0"
-                    maxOccurs="unbounded">
+                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of cooling plant. Zonal cooling is recorded in a separate data field. Use of fans or blowers by themselves without chilled air or water is not included in this definition of cooling. Stand-alone dehumidifiers are also not included.</xs:documentation>
                     </xs:annotation>
@@ -5130,8 +4995,7 @@
             <xs:element name="CondenserPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0"
-                    maxOccurs="unbounded">
+                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of condenser used for refrigerant-based systems.</xs:documentation>
                     </xs:annotation>
@@ -5229,8 +5093,7 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature"
-                                      minOccurs="0">
+                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Minimum outside temperature at which the heat pump can operate. (°F)</xs:documentation>
                                       </xs:annotation>
@@ -5242,8 +5105,7 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes"
-                                      minOccurs="0">
+                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Backup fuel used by the heat pump.</xs:documentation>
                                       </xs:annotation>
@@ -5322,16 +5184,14 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition"
-                          minOccurs="0"/>
+                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for HeatingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType"
-                                maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>Control for HeatingSource.</xs:documentation>
                                 </xs:annotation>
@@ -5384,16 +5244,13 @@
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Split DX air conditioner"/>
-                                          <xs:enumeration
-                                            value="Packaged terminal air conditioner (PTAC)"/>
+                                          <xs:enumeration value="Packaged terminal air conditioner (PTAC)"/>
                                           <xs:enumeration value="Split heat pump"/>
                                           <xs:enumeration value="Packaged terminal heat pump (PTHP)"/>
                                           <xs:enumeration value="Variable refrigerant flow"/>
-                                          <xs:enumeration
-                                            value="Packaged/unitary direct expansion/RTU"/>
+                                          <xs:enumeration value="Packaged/unitary direct expansion/RTU"/>
                                           <xs:enumeration value="Packaged/unitary heat pump"/>
-                                          <xs:enumeration
-                                            value="Single package vertical air conditioner"/>
+                                          <xs:enumeration value="Single package vertical air conditioner"/>
                                           <xs:enumeration value="Single package vertical heat pump"/>
                                           <xs:enumeration value="Other"/>
                                           <xs:enumeration value="Unknown"/>
@@ -5477,16 +5334,14 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition"
-                          minOccurs="0"/>
+                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for CoolingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType"
-                                maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>CoolingSource control.</xs:documentation>
                                 </xs:annotation>
@@ -5541,8 +5396,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5560,8 +5414,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5596,14 +5449,10 @@
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="CAV terminal box no reheat"/>
                                           <xs:enumeration value="CAV terminal box with reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box fan powered no reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box fan powered with reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box not fan powered no reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box not fan powered with reheat"/>
+                                          <xs:enumeration value="VAV terminal box fan powered no reheat"/>
+                                          <xs:enumeration value="VAV terminal box fan powered with reheat"/>
+                                          <xs:enumeration value="VAV terminal box not fan powered no reheat"/>
+                                          <xs:enumeration value="VAV terminal box not fan powered with reheat"/>
                                           <xs:enumeration value="Powered induction unit"/>
                                           <xs:enumeration value="Automatically controlled register"/>
                                           <xs:enumeration value="Manually controlled register"/>
@@ -5684,8 +5533,7 @@
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType"
-                                maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>DeliverySystem control.</xs:documentation>
                                 </xs:annotation>
@@ -5699,8 +5547,7 @@
                         <xs:element ref="auc:ModelNumber" minOccurs="0"/>
                         <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
                         <xs:element ref="auc:Quantity" minOccurs="0"/>
-                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition"
-                          minOccurs="0"/>
+                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition" minOccurs="0"/>
                       </xs:sequence>
                       <xs:attribute name="ID" type="xs:ID" use="required"/>
                       <xs:attribute ref="auc:Status">
@@ -5726,8 +5573,7 @@
       <xs:element name="OtherHVACSystems" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"
-            />
+            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -6013,8 +5859,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of total duct leakage that is on the supply side. Remainder is assumed to be on the return side. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -6419,8 +6264,7 @@
               <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
               <xs:element ref="auc:MinimumPartLoadRatio" minOccurs="0"/>
               <xs:element ref="auc:RatedCoolingSensibleHeatRatio" minOccurs="0"/>
-              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0"
-                type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                 <xs:annotation>
                   <xs:documentation>The part load ratio of the chiller below which hot gas bypass (HGBP) operates. (0-1) (fraction)</xs:documentation>
                 </xs:annotation>
@@ -7319,14 +7163,12 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="MinimumDimmingLightFraction" minOccurs="0"
-              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingLightFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>Minimum light output of controlled lighting when fully dimmed. Minimum light fraction = (Minimum light output) / (Rated light output). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0"
-              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>The minimum power fraction when controlled lighting is fully dimmed. Minimum power fraction = (Minimum power) / (Full rated power). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
@@ -7571,9 +7413,7 @@
                                     <xs:element name="HeatPump" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatedHeatPumpSensibleHeatRatio"
-                                            minOccurs="0"
-                                            type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                                          <xs:element name="RatedHeatPumpSensibleHeatRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                                             <xs:annotation>
                                               <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
                                             </xs:annotation>
@@ -7612,8 +7452,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorArea"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorArea" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Area of solar collector exposed to solar radiation. (ft2)</xs:documentation>
                                             </xs:annotation>
@@ -7625,8 +7464,7 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorLoopType"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorLoopType" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Heat transfer medium and controls used for the solar collector loop.</xs:documentation>
                                             </xs:annotation>
@@ -7642,8 +7480,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorType"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorType" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Type of solar energy collector used in a solar hot water or space heating system.</xs:documentation>
                                             </xs:annotation>
@@ -7660,8 +7497,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorAzimuth"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorAzimuth" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Degrees clockwise from North. For a premises, it is the azimuth of the front facing element. It can also be applied to envelope components, such as walls, windows (fenestration), as well as onsite generation technologies, such as photovoltaic panels. (0 - 360) (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7673,8 +7509,7 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorTilt"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorTilt" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>The angle from a horizontal surface; can be applied to an opaque surface, a fenestration unit, a solar panel, etc. (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7686,8 +7521,7 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemStorageVolume"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemStorageVolume" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Volume of any separate solar energy storage tank, not the primary service hot water tank. (gal)</xs:documentation>
                                             </xs:annotation>
@@ -7705,11 +7539,9 @@
                                             </xs:annotation>
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="Control"
-                                                  type="auc:ControlGeneralType"
-                                                  maxOccurs="unbounded">
+                                                <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                                   <xs:annotation>
-                                                  <xs:documentation>Solar hot water control.</xs:documentation>
+                                                    <xs:documentation>Solar hot water control.</xs:documentation>
                                                   </xs:annotation>
                                                 </xs:element>
                                               </xs:sequence>
@@ -8891,8 +8723,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="FanPowerMinimumRatio" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="FanPowerMinimumRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>The minimum power draw of the fan, expressed as a ratio of the full load fan power. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -9312,8 +9143,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType"
-                    minOccurs="0">
+                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9344,8 +9174,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition"
-                    minOccurs="0"/>
+                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                   <xs:element name="WallInsulationLocation" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Whether wall insulation is on the inside or outside of the wall.</xs:documentation>
@@ -9530,8 +9359,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType"
-                    minOccurs="0">
+                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9562,8 +9390,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition"
-                    minOccurs="0"/>
+                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
@@ -9710,8 +9537,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType"
-                    minOccurs="0">
+                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9742,8 +9568,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition"
-                    minOccurs="0"/>
+                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                   <xs:element name="RoofInsulationRValue" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Insulation R Value of the layer. (hr-ft2-F/Btu)</xs:documentation>
@@ -10240,8 +10065,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0"
-                    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                     <xs:annotation>
                       <xs:documentation>Fraction of door area that is glazed. (0-1) (fraction)</xs:documentation>
                     </xs:annotation>
@@ -10580,8 +10404,7 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="FloorInsulationCondition"
-                                      type="auc:InsulationCondition" minOccurs="0"/>
+                                    <xs:element name="FloorInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                                     <xs:element name="FloorRValue" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>(Also known as thermal resistance), quantity determined by the temperature difference, at steady state, between two defined surfaces of a material or construction that induces a unit heat flow rate through unit area (R = ΔT/q). R-value is the reciprocal of thermal conductance. A unit of thermal resistance used for comparing insulating values of different materials, for the specific thickness of the material. The higher the R-value number, a material, the greater its insulating properties and the slower the heat flow through it. This R-value does not include the interior and exterior air film coefficients. (hr-ft2-F/Btu)</xs:documentation>
@@ -10650,14 +10473,11 @@
                                   <xs:sequence>
                                     <xs:element ref="auc:FoundationWallConstruction" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationHeightAboveGrade" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationThickness"
-                                      minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationThickness" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallRValue" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallUFactor" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationContinuity"
-                                      minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationCondition"
-                                      minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationContinuity" minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationCondition" minOccurs="0"/>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -10974,8 +10794,7 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:WeightedAverageLoad" minOccurs="0"/>
-      <xs:element name="HeatGainFraction" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="HeatGainFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of installed power that results in heat gain to the space. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -11169,8 +10988,7 @@
                         <xs:element name="PV" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray"
-                                minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Number of modules in each array of a photovoltaic system.</xs:documentation>
                                 </xs:annotation>
@@ -11230,8 +11048,7 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin"
-                                minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Minimum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -11243,8 +11060,7 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax"
-                                minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Maximum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -11335,8 +11151,7 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="OutputResourceType" type="auc:FuelTypes"
-                                minOccurs="0">
+                              <xs:element name="OutputResourceType" type="auc:FuelTypes" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Resource or fuel produced by the generation system and used as energy on the premises.</xs:documentation>
                                 </xs:annotation>
@@ -11607,8 +11422,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Average fraction of water use for this application that is drawn from the hot water system. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -13882,59 +13696,37 @@
       <xs:enumeration value="Professional Engineer (PE)"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Certified Member Agency"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Test and Balance Technician"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Demand Side Manager (CDSM)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
       <xs:enumeration value="Association of Energy Engineers Energy Efficiency Practitioner (EEP)"/>
       <xs:enumeration value="Association of Energy Engineers Renewable Energy Professional (REP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
+      <xs:enumeration value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
+      <xs:enumeration value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Manager (CEM)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Auditor (CEA)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 1"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 2"/>
       <xs:enumeration value="Building Performance Institute (BPI) Certification"/>
       <xs:enumeration value="Building Performance Institute (BPI): Building Analyst (BA)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
       <xs:enumeration value="Building Performance Institute (BPI): Multifamily Building Analyst"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) Certification"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) - Home Partner"/>
@@ -14144,8 +13936,7 @@
   </xs:complexType>
   <xs:complexType name="FanBasedType">
     <xs:sequence>
-      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType"
-        minOccurs="0"/>
+      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType" minOccurs="0"/>
       <xs:element name="AirSideEconomizer" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
@@ -14537,8 +14328,7 @@
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType"
-              minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Daylighting control strategy.</xs:documentation>
               </xs:annotation>
@@ -14621,8 +14411,7 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType"
-                minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
                 </xs:annotation>
@@ -14636,8 +14425,7 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType"
-                minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
                 </xs:annotation>
@@ -15232,8 +15020,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="auc:FenestrationArea" minOccurs="0"/>
-        <xs:element name="WindowToWallRatio" minOccurs="0"
-          type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+        <xs:element name="WindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
           <xs:annotation>
             <xs:documentation>Ratio of total window area to total wall area. (0-1) (fraction)</xs:documentation>
           </xs:annotation>
@@ -15280,32 +15067,26 @@
                         <xs:element name="ResponseVariable" minOccurs="1" maxOccurs="1">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ResponseVariableName" type="auc:FuelTypes"
-                                minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType"
-                                minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType"
-                                minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableName" type="auc:FuelTypes" minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType" minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType" minOccurs="1" maxOccurs="1"/>
                             </xs:sequence>
                           </xs:complexType>
                         </xs:element>
                         <xs:element name="ExplanatoryVariables">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ExplanatoryVariable" minOccurs="1"
-                                maxOccurs="unbounded">
+                              <xs:element name="ExplanatoryVariable" minOccurs="1" maxOccurs="unbounded">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="ExplanatoryVariableName" minOccurs="1"
-                                      maxOccurs="1">
+                                    <xs:element name="ExplanatoryVariableName" minOccurs="1" maxOccurs="1">
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Drybulb Temperature"/>
                                           <xs:enumeration value="Wetbulb Temperature"/>
                                           <xs:enumeration value="Relative Humidity"/>
                                           <xs:enumeration value="Global Horizontal Irradiance (GHI)"/>
-                                          <xs:enumeration
-                                            value="Diffuse Horizontal Irradiance (DHI)"/>
+                                          <xs:enumeration value="Diffuse Horizontal Irradiance (DHI)"/>
                                           <xs:enumeration value="Direct Normal Irradiance (DNI)"/>
                                           <xs:enumeration value="Hour of week">
                                             <xs:annotation>
@@ -15371,8 +15152,7 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"
-                                      > </xs:element>
+                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"> </xs:element>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -15402,8 +15182,7 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0"
-                                maxOccurs="1">
+                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0" maxOccurs="1">
                                 <xs:annotation>
                                   <xs:documentation>The 'y-intercept' value.  In Figure D-1 (a), this is Eb.  In Figure D-1 (a)-(g), this is C.</xs:documentation>
                                 </xs:annotation>
@@ -15519,32 +15298,27 @@
                   <xs:element name="SummaryInformation" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of periods in the Baseline period data.  It is denoted as "n" throughout B4.  A "period" refers to a measurement of the ResponseVariable.  For example, 24 hours worth of data collected at hourly intervals would have 24 "periods".</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of parameters in the model.  It is denoted as "p" throughout B4.  The number of parameters is not necessarily equal to the number of auc:ExplanatoryVariable elements.  For example, a 5 parameter change point model has 5 parameters, even though there is only a single ExplanatoryVariable (likely Drybulb Temperature).  In certain cases, this is used in the calculation of the degrees of freedom for the t-statistic.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>Degrees of Freedom as used in the context of a t-distribution.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the actual energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits. See: the Retrofit Isolation Approach (G-14 4.1.1) and Whole Facility Approach (G-14 4.1.2) of ASHRAE Guideline 14-2018.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the model estimated energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                           </xs:annotation>
@@ -15603,26 +15377,22 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1"
-                    maxOccurs="1">
+                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The beginning of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1"
-                    maxOccurs="1">
+                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The end of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the actual energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the model estimated energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
@@ -15632,38 +15402,32 @@
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. As documented in Annex B4.1g and the result of Equation B-14 of ASHRAE Guideline 14-2018 (E_save,m), this value represents the 'actual savings'.  It is calculated via the following: E_save,m = Ehat_base,m - E_meas,m.  In BuildingSync terms, the AvoidedEnergyUse = ComparisonPeriodAggregateModeledEnergyUse - ComparisonPeriodAggregateActualEnergyUse.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0"
-                    maxOccurs="1">
+                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The savings uncertainty represented as a decimal.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The confidence level represented as a decimal between zero and one.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse"
-                    type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized baseline energy use", or the predicted energy consumption using the Baseline model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse"
-                    type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized postretrofit energy use", or the predicted energy consumption using the Reporting (or postretrofit) model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "normalized savings is then defined as the normalized baseline energy use minus the normalized postretrofit energy use".  The "normalized baseline energy use" referred to in G-14 is captured by the auc:BaselinePeriodCalculatedEnergyUseStandardConditions element, while the "normalized postretrofit energy use" is captured by the auc:ReportingPeriodCalculatedEnergyUseStandardConditions element.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0"
-                    maxOccurs="1">
+                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. Used to capture the modeled timeseries data associated with the comparison period.</xs:documentation>
                     </xs:annotation>
@@ -15673,8 +15437,7 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the baseline period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15684,8 +15447,7 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the reporting period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15739,9 +15501,7 @@
     <xs:annotation>
       <xs:documentation>Enumeration for different potential units.</xs:documentation>
     </xs:annotation>
-    <xs:union
-      memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"
-    />
+    <xs:union memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"/>
   </xs:simpleType>
   <xs:simpleType name="DimensionlessUnitsType">
     <xs:union memberTypes="auc:OtherUnitsType auc:DimensionlessUnitsBaseType"/>
@@ -16455,8 +16215,7 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="HeatingStageCapacityFraction"
-    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="HeatingStageCapacityFraction" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>Average capacity of each heating stage, at Air-Conditioning, Heating, and Refrigeration Institute (AHRI) rated conditions, expressed as a fraction of total capacity. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -16800,8 +16559,7 @@
       <xs:documentation>The name or title of rate period.  This is intended to capture the seasonal changes in rates.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RatedCoolingSensibleHeatRatio"
-    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="RatedCoolingSensibleHeatRatio" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -17094,8 +16852,7 @@
   <xs:element name="SpatialUnits">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1"
-          maxOccurs="unbounded"/>
+        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -15966,7 +15966,7 @@
   </xs:element>
   <xs:element name="AnnualSavingsAverageGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Average GHG emissions savings per year. (metric tons CO2e/year)</xs:documentation>
+      <xs:documentation>Average GHG emissions savings per year. (MtCO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3134,7 +3134,7 @@
                   </xs:element>
                   <xs:element name="AvoidedEmissions" minOccurs="0">
                     <xs:annotation>
-                      <xs:documentation>The avoided Greenhouse gas (GHG) emissions resulting from a renewable energy source or a system. (MtCO2e)</xs:documentation>
+                      <xs:documentation>The avoided Greenhouse gas (GHG) emissions resulting from a renewable energy source or a system. (kg CO2e)</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
                       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3524,7 +3524,7 @@
       </xs:element>
       <xs:element name="AnnualMarginalGHGEmissions" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Annual Marginal GHG Emissions. (metric tons CO2e)</xs:documentation>
+          <xs:documentation>Annual Marginal GHG Emissions. (MtCO2e)</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3226,7 +3226,7 @@
                   </xs:element>
                   <xs:element name="AvoidedEmissions" minOccurs="0">
                     <xs:annotation>
-                      <xs:documentation>The avoided Greenhouse gas (GHG) emissions resulting from a renewable energy source or a system. (metric tons CO2e)</xs:documentation>
+                      <xs:documentation>The avoided Greenhouse gas (GHG) emissions resulting from a renewable energy source or a system. (MtCO2e)</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
                       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3131,7 +3131,7 @@
                   </xs:element>
                   <xs:element minOccurs="0" name="EmissionsLinkedTimeSeriesIDs">
                     <xs:annotation>
-                      <xs:documentation>Links to all time series data used to calculate the GHGEmissions</xs:documentation>
+                      <xs:documentation>Links to all time series data used to calculate the total GHG Emissions</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.4.0">
-  <xs:import namespace="http://www.gbxml.org/schema" schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019"
+  xmlns:gbxml="http://www.gbxml.org/schema"
+  targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified"
+  attributeFormDefault="unqualified" version="2.4.0">
+  <xs:import namespace="http://www.gbxml.org/schema"
+    schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
   <xs:annotation>
     <xs:documentation>BuildingSync Schema - Version 2.4.0</xs:documentation>
     <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -80,154 +85,178 @@
                           <xs:element name="HVACSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HVACSystem" type="auc:HVACSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="HVACSystem" type="auc:HVACSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LightingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LightingSystem" type="auc:LightingSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="LightingSystem" type="auc:LightingSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DomesticHotWaterSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DomesticHotWaterSystem" type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="DomesticHotWaterSystem"
+                                  type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CookingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CookingSystem" type="auc:CookingSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="CookingSystem" type="auc:CookingSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RefrigerationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RefrigerationSystem" type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="RefrigerationSystem"
+                                  type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DishwasherSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LaundrySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType" maxOccurs="unbounded"/>
+                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PumpSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PumpSystem" type="auc:PumpSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="PumpSystem" type="auc:PumpSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FanSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FanSystem" type="auc:FanSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FanSystem" type="auc:FanSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="MotorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="MotorSystem" type="auc:MotorSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="MotorSystem" type="auc:MotorSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="HeatRecoverySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HeatRecoverySystem" type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
+                                <xs:element name="HeatRecoverySystem"
+                                  type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="WallSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WallSystem" type="auc:WallSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="WallSystem" type="auc:WallSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RoofSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RoofSystem" type="auc:RoofSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="RoofSystem" type="auc:RoofSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CeilingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FenestrationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FenestrationSystem" type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FenestrationSystem"
+                                  type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ExteriorFloorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ExteriorFloorSystem" type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="ExteriorFloorSystem"
+                                  type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FoundationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CriticalITSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PlugLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType" maxOccurs="unbounded"/>
+                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ProcessLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType" maxOccurs="unbounded"/>
+                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ConveyanceSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="OnsiteStorageTransmissionGenerationSystems" minOccurs="0">
+                          <xs:element name="OnsiteStorageTransmissionGenerationSystems"
+                            minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="OnsiteStorageTransmissionGenerationSystem" type="auc:OnsiteStorageTransmissionGenerationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="OnsiteStorageTransmissionGenerationSystem"
+                                  type="auc:OnsiteStorageTransmissionGenerationSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -241,7 +270,8 @@
                           <xs:element name="WaterUses" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WaterUse" type="auc:WaterUseType" maxOccurs="unbounded"/>
+                                <xs:element name="WaterUse" type="auc:WaterUseType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -254,12 +284,14 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="AirInfiltrationNotes" type="xs:string" minOccurs="0">
+                                      <xs:element name="AirInfiltrationNotes" type="xs:string"
+                                        minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="Tightness" type="auc:Tightness" minOccurs="0">
+                                      <xs:element name="Tightness" type="auc:Tightness"
+                                        minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Description of the infiltration characteristics for an opaque surface, fenestration unit, a thermal zone.</xs:documentation>
                                         </xs:annotation>
@@ -324,15 +356,19 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="WaterInfiltrationNotes" type="xs:string" minOccurs="0">
+                                      <xs:element name="WaterInfiltrationNotes" type="xs:string"
+                                        minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages" minOccurs="0">
+                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages"
+                                        minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element name="LocationsOfExteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element
+                                              name="LocationsOfExteriorWaterIntrusionDamage"
+                                              minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the outside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -352,10 +388,13 @@
                                           </xs:sequence>
                                         </xs:complexType>
                                       </xs:element>
-                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages" minOccurs="0">
+                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages"
+                                        minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element name="LocationsOfInteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element
+                                              name="LocationsOfInteriorWaterIntrusionDamage"
+                                              minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the inside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -385,7 +424,8 @@
                     <xs:element name="Schedules" minOccurs="0">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"/>
+                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"
+                          />
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
@@ -723,12 +763,14 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="OverallWindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallWindowToWallRatio" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall window to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="OverallDoorToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallDoorToWallRatio" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall door to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -788,8 +830,10 @@
                         <xs:enumeration value="ENERGY STAR"/>
                         <xs:enumeration value="ENERGY STAR Certified Homes"/>
                         <xs:enumeration value="LEED"/>
-                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
-                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
+                        <xs:enumeration
+                          value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
+                        <xs:enumeration
+                          value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
                         <xs:enumeration value="Passive House"/>
                         <xs:enumeration value="Living Building Challenge"/>
                         <xs:enumeration value="Green Globes"/>
@@ -1082,7 +1126,8 @@
                                 <xs:element name="WallIDs">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WallID" minOccurs="0" maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WallID" minOccurs="0"
+                                        maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1092,7 +1137,8 @@
                                 <xs:element name="WindowIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WindowID" minOccurs="0" maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WindowID" minOccurs="0"
+                                        maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1102,7 +1148,8 @@
                                 <xs:element name="DoorIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:DoorID" minOccurs="0" maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:DoorID" minOccurs="0"
+                                        maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1156,7 +1203,8 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition" minOccurs="0">
+                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition"
+                                      minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Description of the roof's condition.</xs:documentation>
                                       </xs:annotation>
@@ -1167,7 +1215,8 @@
                                       </xs:annotation>
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="SkylightID" minOccurs="0" maxOccurs="unbounded">
+                                          <xs:element name="SkylightID" minOccurs="0"
+                                            maxOccurs="unbounded">
                                             <xs:annotation>
                                               <xs:documentation>ID number of the skylight type associated with this side of the section.</xs:documentation>
                                             </xs:annotation>
@@ -1175,18 +1224,19 @@
                                               <xs:sequence>
                                                 <xs:element name="PercentSkylightArea" minOccurs="0">
                                                   <xs:annotation>
-                                                    <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
+                                                  <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
                                                   </xs:annotation>
                                                   <xs:complexType>
-                                                    <xs:simpleContent>
-                                                      <xs:extension base="xs:decimal">
-                                                        <xs:attribute ref="auc:Source"/>
-                                                      </xs:extension>
-                                                    </xs:simpleContent>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:decimal">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
-                                              <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
+                                              <xs:attribute name="IDref" type="xs:IDREF"
+                                                use="required"/>
                                             </xs:complexType>
                                           </xs:element>
                                         </xs:sequence>
@@ -1421,7 +1471,8 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ThermalZone" type="auc:ThermalZoneType" maxOccurs="unbounded"/>
+                        <xs:element name="ThermalZone" type="auc:ThermalZoneType"
+                          maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
@@ -2049,7 +2100,8 @@
                         <xs:element name="StandardPractice" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="StandardPracticeDescription" type="xs:string" minOccurs="0">
+                              <xs:element name="StandardPracticeDescription" type="xs:string"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the standard practice represented by this scenario (e.g., builder standard practice, portfolio average, local practice).</xs:documentation>
                                 </xs:annotation>
@@ -2061,7 +2113,8 @@
                         <xs:element name="Other" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="OtherBenchmarkDescription" type="xs:string" minOccurs="0">
+                              <xs:element name="OtherBenchmarkDescription" type="xs:string"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the benchmark scenario (e.g., original design, building next door).</xs:documentation>
                                 </xs:annotation>
@@ -2173,7 +2226,8 @@
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(d)</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh" minOccurs="0">
+                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh"
+                          minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(e)</xs:documentation>
                           </xs:annotation>
@@ -2401,7 +2455,8 @@
       <xs:element name="AllResourceTotals" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType" maxOccurs="unbounded"/>
+            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType"
+              maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -2471,16 +2526,22 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0"
+                                      maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                          <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
+                                          <xs:element ref="auc:DemandRatchetPercentage"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
                                           <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
                                           <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
@@ -2504,52 +2565,69 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0"
+                                      maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
+                                            minOccurs="0"/>
                                           <xs:element name="TimeOfUsePeriods" minOccurs="0">
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="TimeOfUsePeriod" minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="TimeOfUsePeriod" minOccurs="0"
+                                                  maxOccurs="unbounded">
                                                   <xs:complexType>
-                                                    <xs:sequence>
-                                                      <xs:element name="TOUNumberForRateStructure" type="xs:int" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The number associated with the TOU period.</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableStartTimeForEnergyRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableEndTimeForEnergyRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableStartTimeForDemandRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableEndTimeForDemandRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                      <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
-                                                      <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
-                                                      <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
-                                                      <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                      <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
-                                                    </xs:sequence>
+                                                  <xs:sequence>
+                                                  <xs:element name="TOUNumberForRateStructure"
+                                                  type="xs:int" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The number associated with the TOU period.</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element
+                                                  name="ApplicableStartTimeForEnergyRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element name="ApplicableEndTimeForEnergyRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element
+                                                  name="ApplicableStartTimeForDemandRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element name="ApplicableEndTimeForDemandRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                  <xs:element ref="auc:ElectricDemandRate"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:EnergyRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRatchetPercentage"
+                                                  minOccurs="0"/>
+                                                  </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
@@ -2577,66 +2655,80 @@
                                     <xs:element name="RatePeriods" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+                                          <xs:element name="RatePeriod" minOccurs="0"
+                                            maxOccurs="unbounded">
                                             <xs:complexType>
                                               <xs:sequence>
                                                 <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
+                                                <xs:element
+                                                  ref="auc:ApplicableStartDateForEnergyRate"
+                                                  minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate"
+                                                  minOccurs="0"/>
+                                                <xs:element
+                                                  ref="auc:ApplicableStartDateForDemandRate"
+                                                  minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForDemandRate"
+                                                  minOccurs="0"/>
                                                 <xs:element name="RateTiers" minOccurs="0">
                                                   <xs:complexType>
-                                                    <xs:sequence>
-                                                      <xs:element name="RateTier" minOccurs="0" maxOccurs="unbounded">
-                                                        <xs:complexType>
-                                                          <xs:sequence>
-                                                            <xs:element name="ConsumptionEnergyTierDesignation" minOccurs="0">
-                                                            <xs:annotation>
-                                                            <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
-                                                            </xs:annotation>
-                                                            <xs:complexType>
-                                                            <xs:simpleContent>
-                                                            <xs:extension base="xs:integer">
-                                                            <xs:attribute ref="auc:Source"/>
-                                                            </xs:extension>
-                                                            </xs:simpleContent>
-                                                            </xs:complexType>
-                                                            </xs:element>
-                                                            <xs:element name="MaxkWhUsage" minOccurs="0">
-                                                            <xs:annotation>
-                                                            <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
-                                                            </xs:annotation>
-                                                            <xs:complexType>
-                                                            <xs:simpleContent>
-                                                            <xs:extension base="xs:decimal">
-                                                            <xs:attribute ref="auc:Source"/>
-                                                            </xs:extension>
-                                                            </xs:simpleContent>
-                                                            </xs:complexType>
-                                                            </xs:element>
-                                                            <xs:element name="MaxkWUsage" minOccurs="0">
-                                                            <xs:annotation>
-                                                            <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
-                                                            </xs:annotation>
-                                                            <xs:complexType>
-                                                            <xs:simpleContent>
-                                                            <xs:extension base="xs:decimal">
-                                                            <xs:attribute ref="auc:Source"/>
-                                                            </xs:extension>
-                                                            </xs:simpleContent>
-                                                            </xs:complexType>
-                                                            </xs:element>
-                                                            <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                            <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
-                                                            <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
-                                                            <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
-                                                            <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                            <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
-                                                          </xs:sequence>
-                                                        </xs:complexType>
-                                                      </xs:element>
-                                                    </xs:sequence>
+                                                  <xs:sequence>
+                                                  <xs:element name="RateTier" minOccurs="0"
+                                                  maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element
+                                                  name="ConsumptionEnergyTierDesignation"
+                                                  minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
+                                                  </xs:annotation>
+                                                  <xs:complexType>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:integer">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element name="MaxkWhUsage" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
+                                                  </xs:annotation>
+                                                  <xs:complexType>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:decimal">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element name="MaxkWUsage" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
+                                                  </xs:annotation>
+                                                  <xs:complexType>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:decimal">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                  <xs:element ref="auc:ElectricDemandRate"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:EnergyRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRatchetPercentage"
+                                                  minOccurs="0"/>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                                 <xs:element ref="auc:EnergySellRate" minOccurs="0"/>
@@ -3110,7 +3202,19 @@
                   </xs:element>
                   <xs:element name="GHGEmissions" minOccurs="0">
                     <xs:annotation>
-                      <xs:documentation>Emissions that result in gases that trap heat in the atmosphere. (kgCO2e)</xs:documentation>
+                      <xs:documentation>Emissions that result in gases that trap heat in the atmosphere. (metric tons CO2e)</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:decimal">
+                          <xs:attribute ref="auc:Source"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element minOccurs="0" name="GHGEmissionIntensity">
+                    <xs:annotation>
+                      <xs:documentation>GHG Emission Intensity (kg CO2e/ft2)</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
                       <xs:simpleContent>
@@ -3122,7 +3226,7 @@
                   </xs:element>
                   <xs:element name="AvoidedEmissions" minOccurs="0">
                     <xs:annotation>
-                      <xs:documentation>The avoided Greenhouse gas (GHG) emissions resulting from a renewable energy source or a system. (kgCO2e)</xs:documentation>
+                      <xs:documentation>The avoided Greenhouse gas (GHG) emissions resulting from a renewable energy source or a system. (metric tons CO2e)</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
                       <xs:simpleContent>
@@ -3138,7 +3242,8 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="1" name="EmissionsLinkedTimeSeriesID">
+                        <xs:element maxOccurs="unbounded" minOccurs="1"
+                          name="EmissionsLinkedTimeSeriesID">
                           <xs:complexType>
                             <xs:attribute name="IDref" type="xs:IDREF"/>
                           </xs:complexType>
@@ -3407,7 +3512,7 @@
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
       <xs:element minOccurs="0" name="AnnualAverageGHGEmissions">
         <xs:annotation>
-          <xs:documentation>Annual Average GHG Emissions. (kg CO2e)</xs:documentation>
+          <xs:documentation>Annual Average GHG Emissions. (metric tons CO2e)</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:simpleContent>
@@ -3419,7 +3524,7 @@
       </xs:element>
       <xs:element name="AnnualMarginalGHGEmissions" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Annual Marginal GHG Emissions. (kg CO2e)</xs:documentation>
+          <xs:documentation>Annual Marginal GHG Emissions. (metric tons CO2e)</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:simpleContent>
@@ -3641,7 +3746,8 @@
                   <xs:element name="Replacement" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemReplaced" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemReplaced" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems replaced by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3649,7 +3755,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element name="AlternativeSystemReplacement" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemReplacement" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would replace the existing systems.</xs:documentation>
                           </xs:annotation>
@@ -3657,7 +3764,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3671,7 +3779,8 @@
                   <xs:element name="ModificationRetrocommissioning" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemAffected" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemAffected" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems affected by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3687,7 +3796,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3701,7 +3811,8 @@
                   <xs:element name="Addition" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="AlternativeSystemAdded" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemAdded" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would be added as part of the measure.</xs:documentation>
                           </xs:annotation>
@@ -3709,7 +3820,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3731,7 +3843,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3810,7 +3923,8 @@
                               <xs:enumeration value="Convert system from steam to hot water"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Convert to Cleaner Fuels"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -3839,7 +3953,8 @@
                               <xs:enumeration value="Add or replace cooling tower"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3863,7 +3978,8 @@
                               <xs:enumeration value="Add or upgrade BAS/EMS/EMCS"/>
                               <xs:enumeration value="Add or upgrade controls"/>
                               <xs:enumeration value="Convert pneumatic controls to DDC"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3895,7 +4011,8 @@
                               <xs:enumeration value="Replace package units"/>
                               <xs:enumeration value="Replace packaged terminal units"/>
                               <xs:enumeration value="Install passive solar heating"/>
-                              <xs:enumeration value="Replace AC and heating units with ground coupled heat pump systems"/>
+                              <xs:enumeration
+                                value="Replace AC and heating units with ground coupled heat pump systems"/>
                               <xs:enumeration value="Add enhanced dehumidification"/>
                               <xs:enumeration value="Install solar ventilation preheating system"/>
                               <xs:enumeration value="Add or repair economizer"/>
@@ -3910,7 +4027,8 @@
                               <xs:enumeration value="Install or Upgrade Master Venting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other heating"/>
                               <xs:enumeration value="Other cooling"/>
                               <xs:enumeration value="Other ventilation"/>
@@ -3938,8 +4056,10 @@
                               <xs:enumeration value="Retrofit with T-5"/>
                               <xs:enumeration value="Retrofit with T-8"/>
                               <xs:enumeration value="Install spectrally enhanced lighting"/>
-                              <xs:enumeration value="Retrofit with fiber optic lighting technologies"/>
-                              <xs:enumeration value="Retrofit with light emitting diode technologies"/>
+                              <xs:enumeration
+                                value="Retrofit with fiber optic lighting technologies"/>
+                              <xs:enumeration
+                                value="Retrofit with light emitting diode technologies"/>
                               <xs:enumeration value="Add daylight controls"/>
                               <xs:enumeration value="Add occupancy sensors"/>
                               <xs:enumeration value="Install photocell control"/>
@@ -3949,7 +4069,8 @@
                               <xs:enumeration value="Upgrade exterior lighting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4007,8 +4128,10 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Add pipe insulation"/>
                               <xs:enumeration value="Repair and/or replace steam traps"/>
-                              <xs:enumeration value="Retrofit and replace chiller plant pumping, piping, and controls"/>
-                              <xs:enumeration value="Repair or replace existing condensate return systems or install new condensate return systems"/>
+                              <xs:enumeration
+                                value="Retrofit and replace chiller plant pumping, piping, and controls"/>
+                              <xs:enumeration
+                                value="Repair or replace existing condensate return systems or install new condensate return systems"/>
                               <xs:enumeration value="Add recirculating pumps"/>
                               <xs:enumeration value="Replace or upgrade water heater"/>
                               <xs:enumeration value="Add energy recovery"/>
@@ -4021,7 +4144,8 @@
                               <xs:enumeration value="Install steam condensate heat recovery"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4046,7 +4170,8 @@
                               <xs:enumeration value="Upgrade motors"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4071,7 +4196,8 @@
                               <xs:enumeration value="Add VSD motor controller"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4091,12 +4217,14 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration value="Replace ice/refrigeration equipment with high efficiency units"/>
+                              <xs:enumeration
+                                value="Replace ice/refrigeration equipment with high efficiency units"/>
                               <xs:enumeration value="Replace air-cooled ice/refrigeration equipment"/>
                               <xs:enumeration value="Replace refrigerators"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4122,7 +4250,8 @@
                               <xs:enumeration value="Convert fuels"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4142,14 +4271,17 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
+                              <xs:enumeration
+                                value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
                               <xs:enumeration value="Install photovoltaic system"/>
                               <xs:enumeration value="Install wind energy system"/>
-                              <xs:enumeration value="Install wood waste or other organic waste stream heating or power plant"/>
+                              <xs:enumeration
+                                value="Install wood waste or other organic waste stream heating or power plant"/>
                               <xs:enumeration value="Install electrical storage"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4175,7 +4307,8 @@
                               <xs:enumeration value="Install gas distribution systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4209,7 +4342,8 @@
                               <xs:enumeration value="Install tankless water heaters"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4235,7 +4369,8 @@
                               <xs:enumeration value="Implement water efficient irrigation"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4257,7 +4392,8 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Install thermal energy storage"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4278,8 +4414,10 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Change to more favorable rate schedule"/>
-                              <xs:enumeration value="Energy cost reduction through rate adjustments - uncategorized"/>
-                              <xs:enumeration value="Energy service billing and meter auditing recommendations"/>
+                              <xs:enumeration
+                                value="Energy cost reduction through rate adjustments - uncategorized"/>
+                              <xs:enumeration
+                                value="Energy service billing and meter auditing recommendations"/>
                               <xs:enumeration value="Change to lower energy cost supplier(s)"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -4301,10 +4439,12 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Implement industrial process improvements"/>
-                              <xs:enumeration value="Implement production and/or manufacturing improvements"/>
+                              <xs:enumeration
+                                value="Implement production and/or manufacturing improvements"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4327,7 +4467,8 @@
                               <xs:enumeration value="Install advanced metering systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4355,7 +4496,8 @@
                               <xs:enumeration value="Replace washing machines"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4382,7 +4524,8 @@
                               <xs:enumeration value="Upgrade servers"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4862,7 +5005,8 @@
               </xs:annotation>
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType" minOccurs="0">
+                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Qualification of auditor responsible for the audit report.</xs:documentation>
                     </xs:annotation>
@@ -4890,7 +5034,8 @@
                       <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="AuditTeamMemberCertificationType" type="auc:AuditorQualificationType" minOccurs="0">
+                  <xs:element name="AuditTeamMemberCertificationType"
+                    type="auc:AuditorQualificationType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Type of certification held by an auditor team member.</xs:documentation>
                     </xs:annotation>
@@ -4961,7 +5106,8 @@
             <xs:element name="HeatingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0" maxOccurs="unbounded">
+                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0"
+                    maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of central heating system, defined as any source of heating energy separate from the zone being heated. Local heating systems (such as packaged systems and fan-coils) are recorded in a separate data field.</xs:documentation>
                     </xs:annotation>
@@ -4972,7 +5118,8 @@
             <xs:element name="CoolingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0" maxOccurs="unbounded">
+                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0"
+                    maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of cooling plant. Zonal cooling is recorded in a separate data field. Use of fans or blowers by themselves without chilled air or water is not included in this definition of cooling. Stand-alone dehumidifiers are also not included.</xs:documentation>
                     </xs:annotation>
@@ -4983,7 +5130,8 @@
             <xs:element name="CondenserPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0" maxOccurs="unbounded">
+                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0"
+                    maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of condenser used for refrigerant-based systems.</xs:documentation>
                     </xs:annotation>
@@ -5081,7 +5229,8 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature" minOccurs="0">
+                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature"
+                                      minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Minimum outside temperature at which the heat pump can operate. (°F)</xs:documentation>
                                       </xs:annotation>
@@ -5093,7 +5242,8 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes" minOccurs="0">
+                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes"
+                                      minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Backup fuel used by the heat pump.</xs:documentation>
                                       </xs:annotation>
@@ -5172,14 +5322,16 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
+                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition"
+                          minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for HeatingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType"
+                                maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>Control for HeatingSource.</xs:documentation>
                                 </xs:annotation>
@@ -5232,13 +5384,16 @@
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Split DX air conditioner"/>
-                                          <xs:enumeration value="Packaged terminal air conditioner (PTAC)"/>
+                                          <xs:enumeration
+                                            value="Packaged terminal air conditioner (PTAC)"/>
                                           <xs:enumeration value="Split heat pump"/>
                                           <xs:enumeration value="Packaged terminal heat pump (PTHP)"/>
                                           <xs:enumeration value="Variable refrigerant flow"/>
-                                          <xs:enumeration value="Packaged/unitary direct expansion/RTU"/>
+                                          <xs:enumeration
+                                            value="Packaged/unitary direct expansion/RTU"/>
                                           <xs:enumeration value="Packaged/unitary heat pump"/>
-                                          <xs:enumeration value="Single package vertical air conditioner"/>
+                                          <xs:enumeration
+                                            value="Single package vertical air conditioner"/>
                                           <xs:enumeration value="Single package vertical heat pump"/>
                                           <xs:enumeration value="Other"/>
                                           <xs:enumeration value="Unknown"/>
@@ -5322,14 +5477,16 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
+                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition"
+                          minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for CoolingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType"
+                                maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>CoolingSource control.</xs:documentation>
                                 </xs:annotation>
@@ -5384,7 +5541,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5402,7 +5560,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5437,10 +5596,14 @@
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="CAV terminal box no reheat"/>
                                           <xs:enumeration value="CAV terminal box with reheat"/>
-                                          <xs:enumeration value="VAV terminal box fan powered no reheat"/>
-                                          <xs:enumeration value="VAV terminal box fan powered with reheat"/>
-                                          <xs:enumeration value="VAV terminal box not fan powered no reheat"/>
-                                          <xs:enumeration value="VAV terminal box not fan powered with reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box fan powered no reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box fan powered with reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box not fan powered no reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box not fan powered with reheat"/>
                                           <xs:enumeration value="Powered induction unit"/>
                                           <xs:enumeration value="Automatically controlled register"/>
                                           <xs:enumeration value="Manually controlled register"/>
@@ -5521,7 +5684,8 @@
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType"
+                                maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>DeliverySystem control.</xs:documentation>
                                 </xs:annotation>
@@ -5535,7 +5699,8 @@
                         <xs:element ref="auc:ModelNumber" minOccurs="0"/>
                         <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
                         <xs:element ref="auc:Quantity" minOccurs="0"/>
-                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition" minOccurs="0"/>
+                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition"
+                          minOccurs="0"/>
                       </xs:sequence>
                       <xs:attribute name="ID" type="xs:ID" use="required"/>
                       <xs:attribute ref="auc:Status">
@@ -5561,7 +5726,8 @@
       <xs:element name="OtherHVACSystems" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"/>
+            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"
+            />
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -5847,7 +6013,8 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of total duct leakage that is on the supply side. Remainder is assumed to be on the return side. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -6252,7 +6419,8 @@
               <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
               <xs:element ref="auc:MinimumPartLoadRatio" minOccurs="0"/>
               <xs:element ref="auc:RatedCoolingSensibleHeatRatio" minOccurs="0"/>
-              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0"
+                type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                 <xs:annotation>
                   <xs:documentation>The part load ratio of the chiller below which hot gas bypass (HGBP) operates. (0-1) (fraction)</xs:documentation>
                 </xs:annotation>
@@ -7151,12 +7319,14 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="MinimumDimmingLightFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingLightFraction" minOccurs="0"
+              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>Minimum light output of controlled lighting when fully dimmed. Minimum light fraction = (Minimum light output) / (Rated light output). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0"
+              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>The minimum power fraction when controlled lighting is fully dimmed. Minimum power fraction = (Minimum power) / (Full rated power). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
@@ -7401,7 +7571,9 @@
                                     <xs:element name="HeatPump" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatedHeatPumpSensibleHeatRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                                          <xs:element name="RatedHeatPumpSensibleHeatRatio"
+                                            minOccurs="0"
+                                            type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                                             <xs:annotation>
                                               <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
                                             </xs:annotation>
@@ -7440,7 +7612,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorArea" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorArea"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Area of solar collector exposed to solar radiation. (ft2)</xs:documentation>
                                             </xs:annotation>
@@ -7452,7 +7625,8 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorLoopType" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorLoopType"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Heat transfer medium and controls used for the solar collector loop.</xs:documentation>
                                             </xs:annotation>
@@ -7468,7 +7642,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorType" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorType"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Type of solar energy collector used in a solar hot water or space heating system.</xs:documentation>
                                             </xs:annotation>
@@ -7485,7 +7660,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorAzimuth" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorAzimuth"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Degrees clockwise from North. For a premises, it is the azimuth of the front facing element. It can also be applied to envelope components, such as walls, windows (fenestration), as well as onsite generation technologies, such as photovoltaic panels. (0 - 360) (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7497,7 +7673,8 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorTilt" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorTilt"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>The angle from a horizontal surface; can be applied to an opaque surface, a fenestration unit, a solar panel, etc. (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7509,7 +7686,8 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemStorageVolume" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemStorageVolume"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Volume of any separate solar energy storage tank, not the primary service hot water tank. (gal)</xs:documentation>
                                             </xs:annotation>
@@ -7527,9 +7705,11 @@
                                             </xs:annotation>
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                                                <xs:element name="Control"
+                                                  type="auc:ControlGeneralType"
+                                                  maxOccurs="unbounded">
                                                   <xs:annotation>
-                                                    <xs:documentation>Solar hot water control.</xs:documentation>
+                                                  <xs:documentation>Solar hot water control.</xs:documentation>
                                                   </xs:annotation>
                                                 </xs:element>
                                               </xs:sequence>
@@ -8711,7 +8891,8 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="FanPowerMinimumRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="FanPowerMinimumRatio" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>The minimum power draw of the fan, expressed as a ratio of the full load fan power. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -9131,7 +9312,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
+                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9162,7 +9344,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition"
+                    minOccurs="0"/>
                   <xs:element name="WallInsulationLocation" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Whether wall insulation is on the inside or outside of the wall.</xs:documentation>
@@ -9347,7 +9530,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
+                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9378,7 +9562,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition"
+                    minOccurs="0"/>
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
@@ -9525,7 +9710,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
+                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9556,7 +9742,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition"
+                    minOccurs="0"/>
                   <xs:element name="RoofInsulationRValue" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Insulation R Value of the layer. (hr-ft2-F/Btu)</xs:documentation>
@@ -10053,7 +10240,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0"
+                    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                     <xs:annotation>
                       <xs:documentation>Fraction of door area that is glazed. (0-1) (fraction)</xs:documentation>
                     </xs:annotation>
@@ -10392,7 +10580,8 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="FloorInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                                    <xs:element name="FloorInsulationCondition"
+                                      type="auc:InsulationCondition" minOccurs="0"/>
                                     <xs:element name="FloorRValue" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>(Also known as thermal resistance), quantity determined by the temperature difference, at steady state, between two defined surfaces of a material or construction that induces a unit heat flow rate through unit area (R = ΔT/q). R-value is the reciprocal of thermal conductance. A unit of thermal resistance used for comparing insulating values of different materials, for the specific thickness of the material. The higher the R-value number, a material, the greater its insulating properties and the slower the heat flow through it. This R-value does not include the interior and exterior air film coefficients. (hr-ft2-F/Btu)</xs:documentation>
@@ -10461,11 +10650,14 @@
                                   <xs:sequence>
                                     <xs:element ref="auc:FoundationWallConstruction" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationHeightAboveGrade" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationThickness" minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationThickness"
+                                      minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallRValue" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallUFactor" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationContinuity" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationCondition" minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationContinuity"
+                                      minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationCondition"
+                                      minOccurs="0"/>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -10782,7 +10974,8 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:WeightedAverageLoad" minOccurs="0"/>
-      <xs:element name="HeatGainFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="HeatGainFraction" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of installed power that results in heat gain to the space. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -10976,7 +11169,8 @@
                         <xs:element name="PV" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray" minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Number of modules in each array of a photovoltaic system.</xs:documentation>
                                 </xs:annotation>
@@ -11036,7 +11230,8 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin" minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Minimum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -11048,7 +11243,8 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax" minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Maximum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -11139,7 +11335,8 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="OutputResourceType" type="auc:FuelTypes" minOccurs="0">
+                              <xs:element name="OutputResourceType" type="auc:FuelTypes"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Resource or fuel produced by the generation system and used as energy on the premises.</xs:documentation>
                                 </xs:annotation>
@@ -11410,7 +11607,8 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Average fraction of water use for this application that is drawn from the hot water system. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -13684,37 +13882,59 @@
       <xs:enumeration value="Professional Engineer (PE)"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Certified Member Agency"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Test and Balance Technician"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Demand Side Manager (CDSM)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
       <xs:enumeration value="Association of Energy Engineers Energy Efficiency Practitioner (EEP)"/>
       <xs:enumeration value="Association of Energy Engineers Renewable Energy Professional (REP)"/>
-      <xs:enumeration value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
-      <xs:enumeration value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Manager (CEM)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Auditor (CEA)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 1"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 2"/>
       <xs:enumeration value="Building Performance Institute (BPI) Certification"/>
       <xs:enumeration value="Building Performance Institute (BPI): Building Analyst (BA)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
       <xs:enumeration value="Building Performance Institute (BPI): Multifamily Building Analyst"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) Certification"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) - Home Partner"/>
@@ -13924,7 +14144,8 @@
   </xs:complexType>
   <xs:complexType name="FanBasedType">
     <xs:sequence>
-      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType" minOccurs="0"/>
+      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType"
+        minOccurs="0"/>
       <xs:element name="AirSideEconomizer" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
@@ -14316,7 +14537,8 @@
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType"
+              minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Daylighting control strategy.</xs:documentation>
               </xs:annotation>
@@ -14399,7 +14621,8 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType" minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType"
+                minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
                 </xs:annotation>
@@ -14413,7 +14636,8 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType" minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType"
+                minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
                 </xs:annotation>
@@ -15008,7 +15232,8 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="auc:FenestrationArea" minOccurs="0"/>
-        <xs:element name="WindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+        <xs:element name="WindowToWallRatio" minOccurs="0"
+          type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
           <xs:annotation>
             <xs:documentation>Ratio of total window area to total wall area. (0-1) (fraction)</xs:documentation>
           </xs:annotation>
@@ -15055,26 +15280,32 @@
                         <xs:element name="ResponseVariable" minOccurs="1" maxOccurs="1">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ResponseVariableName" type="auc:FuelTypes" minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType" minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType" minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableName" type="auc:FuelTypes"
+                                minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType"
+                                minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType"
+                                minOccurs="1" maxOccurs="1"/>
                             </xs:sequence>
                           </xs:complexType>
                         </xs:element>
                         <xs:element name="ExplanatoryVariables">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ExplanatoryVariable" minOccurs="1" maxOccurs="unbounded">
+                              <xs:element name="ExplanatoryVariable" minOccurs="1"
+                                maxOccurs="unbounded">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="ExplanatoryVariableName" minOccurs="1" maxOccurs="1">
+                                    <xs:element name="ExplanatoryVariableName" minOccurs="1"
+                                      maxOccurs="1">
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Drybulb Temperature"/>
                                           <xs:enumeration value="Wetbulb Temperature"/>
                                           <xs:enumeration value="Relative Humidity"/>
                                           <xs:enumeration value="Global Horizontal Irradiance (GHI)"/>
-                                          <xs:enumeration value="Diffuse Horizontal Irradiance (DHI)"/>
+                                          <xs:enumeration
+                                            value="Diffuse Horizontal Irradiance (DHI)"/>
                                           <xs:enumeration value="Direct Normal Irradiance (DNI)"/>
                                           <xs:enumeration value="Hour of week">
                                             <xs:annotation>
@@ -15140,7 +15371,8 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"> </xs:element>
+                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"
+                                      > </xs:element>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -15170,7 +15402,8 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0"
+                                maxOccurs="1">
                                 <xs:annotation>
                                   <xs:documentation>The 'y-intercept' value.  In Figure D-1 (a), this is Eb.  In Figure D-1 (a)-(g), this is C.</xs:documentation>
                                 </xs:annotation>
@@ -15286,27 +15519,32 @@
                   <xs:element name="SummaryInformation" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of periods in the Baseline period data.  It is denoted as "n" throughout B4.  A "period" refers to a measurement of the ResponseVariable.  For example, 24 hours worth of data collected at hourly intervals would have 24 "periods".</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of parameters in the model.  It is denoted as "p" throughout B4.  The number of parameters is not necessarily equal to the number of auc:ExplanatoryVariable elements.  For example, a 5 parameter change point model has 5 parameters, even though there is only a single ExplanatoryVariable (likely Drybulb Temperature).  In certain cases, this is used in the calculation of the degrees of freedom for the t-statistic.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>Degrees of Freedom as used in the context of a t-distribution.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the actual energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits. See: the Retrofit Isolation Approach (G-14 4.1.1) and Whole Facility Approach (G-14 4.1.2) of ASHRAE Guideline 14-2018.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the model estimated energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                           </xs:annotation>
@@ -15365,22 +15603,26 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The beginning of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The end of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the actual energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the model estimated energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
@@ -15390,32 +15632,38 @@
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. As documented in Annex B4.1g and the result of Equation B-14 of ASHRAE Guideline 14-2018 (E_save,m), this value represents the 'actual savings'.  It is calculated via the following: E_save,m = Ehat_base,m - E_meas,m.  In BuildingSync terms, the AvoidedEnergyUse = ComparisonPeriodAggregateModeledEnergyUse - ComparisonPeriodAggregateActualEnergyUse.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The savings uncertainty represented as a decimal.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The confidence level represented as a decimal between zero and one.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse"
+                    type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized baseline energy use", or the predicted energy consumption using the Baseline model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse"
+                    type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized postretrofit energy use", or the predicted energy consumption using the Reporting (or postretrofit) model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "normalized savings is then defined as the normalized baseline energy use minus the normalized postretrofit energy use".  The "normalized baseline energy use" referred to in G-14 is captured by the auc:BaselinePeriodCalculatedEnergyUseStandardConditions element, while the "normalized postretrofit energy use" is captured by the auc:ReportingPeriodCalculatedEnergyUseStandardConditions element.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. Used to capture the modeled timeseries data associated with the comparison period.</xs:documentation>
                     </xs:annotation>
@@ -15425,7 +15673,8 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the baseline period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15435,7 +15684,8 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the reporting period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15489,7 +15739,9 @@
     <xs:annotation>
       <xs:documentation>Enumeration for different potential units.</xs:documentation>
     </xs:annotation>
-    <xs:union memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"/>
+    <xs:union
+      memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"
+    />
   </xs:simpleType>
   <xs:simpleType name="DimensionlessUnitsType">
     <xs:union memberTypes="auc:OtherUnitsType auc:DimensionlessUnitsBaseType"/>
@@ -15714,7 +15966,7 @@
   </xs:element>
   <xs:element name="AnnualSavingsAverageGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Average GHG emissions savings per year. (kg CO2e/year)</xs:documentation>
+      <xs:documentation>Average GHG emissions savings per year. (metric tons CO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -15726,7 +15978,7 @@
   </xs:element>
   <xs:element name="AnnualSavingsMarginalGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Marginal GHG emissions savings per year. (kg CO2e/year)</xs:documentation>
+      <xs:documentation>Marginal GHG emissions savings per year. (metric tons CO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -16203,7 +16455,8 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="HeatingStageCapacityFraction" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="HeatingStageCapacityFraction"
+    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>Average capacity of each heating stage, at Air-Conditioning, Heating, and Refrigeration Institute (AHRI) rated conditions, expressed as a fraction of total capacity. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -16547,7 +16800,8 @@
       <xs:documentation>The name or title of rate period.  This is intended to capture the seasonal changes in rates.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RatedCoolingSensibleHeatRatio" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="RatedCoolingSensibleHeatRatio"
+    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -16840,7 +17094,8 @@
   <xs:element name="SpatialUnits">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1"
+          maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -2119,6 +2119,7 @@
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualSavingsAverageGHGEmissions" minOccurs="0"/>
                   <xs:element ref="auc:AnnualSavingsMarginalGHGEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsGHGEmissionIntensity" minOccurs="0"/>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -2203,6 +2204,7 @@
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualSavingsAverageGHGEmissions" minOccurs="0"/>
                   <xs:element ref="auc:AnnualSavingsMarginalGHGEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsGHGEmissionIntensity" minOccurs="0"/>
                   <xs:element name="ImplementationPeriod" type="xs:integer" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Total period of time necessary to implement all measures in the package. (months)</xs:documentation>
@@ -2317,6 +2319,7 @@
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualSavingsAverageGHGEmissions" minOccurs="0"/>
                   <xs:element ref="auc:AnnualSavingsMarginalGHGEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsGHGEmissionIntensity" minOccurs="0"/>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -3417,6 +3420,18 @@
       <xs:element name="AnnualMarginalGHGEmissions" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Annual Marginal GHG Emissions. (kg CO2e)</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:decimal">
+              <xs:attribute ref="auc:Source"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="AnnualGHGEmissionIntensity" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Annual GHG Emission Intensity. (kg CO2e/ft2/year)</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:simpleContent>
@@ -15712,6 +15727,18 @@
   <xs:element name="AnnualSavingsMarginalGHGEmissions">
     <xs:annotation>
       <xs:documentation>Marginal GHG emissions savings per year. (kg CO2e/year)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AnnualSavingsGHGEmissionIntensity">
+    <xs:annotation>
+      <xs:documentation>Annual GHG emissions intensity savings per year. (kg CO2e/ft2/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3202,7 +3202,7 @@
                   </xs:element>
                   <xs:element name="GHGEmissions" minOccurs="0">
                     <xs:annotation>
-                      <xs:documentation>Emissions that result in gases that trap heat in the atmosphere. (metric tons CO2e)</xs:documentation>
+                      <xs:documentation>Emissions that result in gases that trap heat in the atmosphere. (MtCO2e)</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
                       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3512,7 +3512,7 @@
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
       <xs:element minOccurs="0" name="AnnualAverageGHGEmissions">
         <xs:annotation>
-          <xs:documentation>Annual Average GHG Emissions. (metric tons CO2e)</xs:documentation>
+          <xs:documentation>Annual Average GHG Emissions. (MtCO2e)</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -2170,30 +2170,8 @@
                   <xs:element ref="auc:AnnualPeakElectricityReduction" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
-                  <xs:element minOccurs="0" name="AnnualSavingsAverageCarbonEmissions">
-                    <xs:annotation>
-                      <xs:documentation>Average carbon emissions savings per year. (kg CO2e)</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:decimal">
-                          <xs:attribute ref="auc:Source"/>
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
-                    <xs:annotation>
-                      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e)</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:decimal">
-                          <xs:attribute ref="auc:Source"/>
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
+                  <xs:element ref="auc:AnnualSavingsAverageCarbonEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsMarginalCarbonEmissions" minOccurs="0"/>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -2277,30 +2255,8 @@
                   <xs:element ref="auc:AnnualDemandSavingsCost" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
-                  <xs:element minOccurs="0" name="AnnualSavingsAverageCarbonEmissions">
-                    <xs:annotation>
-                      <xs:documentation>Average carbon emissions savings per year. (kg CO2e)</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:decimal">
-                          <xs:attribute ref="auc:Source"/>
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
-                    <xs:annotation>
-                      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e)</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:decimal">
-                          <xs:attribute ref="auc:Source"/>
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
+                  <xs:element ref="auc:AnnualSavingsAverageCarbonEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsMarginalCarbonEmissions" minOccurs="0"/>
                   <xs:element name="ImplementationPeriod" type="xs:integer" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Total period of time necessary to implement all measures in the package. (months)</xs:documentation>
@@ -2413,30 +2369,8 @@
                   <xs:element ref="auc:AnnualPeakElectricityReduction" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
-                  <xs:element minOccurs="0" name="AnnualSavingsAverageCarbonEmissions">
-                    <xs:annotation>
-                      <xs:documentation>Average carbon emissions savings per year. (kg CO2e)</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:decimal">
-                          <xs:attribute ref="auc:Source"/>
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
-                    <xs:annotation>
-                      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e)</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:decimal">
-                          <xs:attribute ref="auc:Source"/>
-                        </xs:extension>
-                      </xs:simpleContent>
-                    </xs:complexType>
-                  </xs:element>
+                  <xs:element ref="auc:AnnualSavingsAverageCarbonEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsMarginalCarbonEmissions" minOccurs="0"/>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -3293,7 +3227,8 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="1" name="LinkedTimeSeriesID">
+                        <xs:element maxOccurs="unbounded" minOccurs="1"
+                          name="EmissionsLinkedTimeSeriesID">
                           <xs:complexType>
                             <xs:attribute name="IDref" type="xs:IDREF"/>
                           </xs:complexType>
@@ -3572,7 +3507,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="AnnualMarginalCarbonEmissions">
+      <xs:element name="AnnualMarginalCarbonEmissions" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Annual Marginal Carbon Emissions. (kg CO2e)</xs:documentation>
         </xs:annotation>
@@ -16000,6 +15935,30 @@
   <xs:element name="AnnualWaterSavings">
     <xs:annotation>
       <xs:documentation>Total annual water savings (hot and cold). (gal/year)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AnnualSavingsAverageCarbonEmissions">
+    <xs:annotation>
+      <xs:documentation>Average carbon emissions savings per year. (kg CO2e/year)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
+    <xs:annotation>
+      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3484,7 +3484,7 @@
             <xs:enumeration value="Frequency"/>
             <xs:enumeration value="Power"/>
             <xs:enumeration value="Power Factor"/>
-            <xs:enumeration value="Emissions"/>
+            <xs:enumeration value="Greenhouse Gas Emissions"/>
             <xs:enumeration value="Energy"/>
             <xs:enumeration value="Voltage"/>
             <xs:enumeration value="Voltage Angle"/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -15978,7 +15978,7 @@
   </xs:element>
   <xs:element name="AnnualSavingsMarginalGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Marginal GHG emissions savings per year. (metric tons CO2e/year)</xs:documentation>
+      <xs:documentation>Marginal GHG emissions savings per year. (MtCO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.4.0">
-  <xs:import namespace="http://www.gbxml.org/schema" schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019"
+  xmlns:gbxml="http://www.gbxml.org/schema"
+  targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified"
+  attributeFormDefault="unqualified" version="2.4.0">
+  <xs:import namespace="http://www.gbxml.org/schema"
+    schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
   <xs:annotation>
     <xs:documentation>BuildingSync Schema - Version 2.4.0</xs:documentation>
     <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -80,154 +85,178 @@
                           <xs:element name="HVACSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HVACSystem" type="auc:HVACSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="HVACSystem" type="auc:HVACSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LightingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LightingSystem" type="auc:LightingSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="LightingSystem" type="auc:LightingSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DomesticHotWaterSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DomesticHotWaterSystem" type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="DomesticHotWaterSystem"
+                                  type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CookingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CookingSystem" type="auc:CookingSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="CookingSystem" type="auc:CookingSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RefrigerationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RefrigerationSystem" type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="RefrigerationSystem"
+                                  type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DishwasherSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LaundrySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType" maxOccurs="unbounded"/>
+                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PumpSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PumpSystem" type="auc:PumpSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="PumpSystem" type="auc:PumpSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FanSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FanSystem" type="auc:FanSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FanSystem" type="auc:FanSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="MotorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="MotorSystem" type="auc:MotorSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="MotorSystem" type="auc:MotorSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="HeatRecoverySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HeatRecoverySystem" type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
+                                <xs:element name="HeatRecoverySystem"
+                                  type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="WallSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WallSystem" type="auc:WallSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="WallSystem" type="auc:WallSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RoofSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RoofSystem" type="auc:RoofSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="RoofSystem" type="auc:RoofSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CeilingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FenestrationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FenestrationSystem" type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FenestrationSystem"
+                                  type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ExteriorFloorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ExteriorFloorSystem" type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="ExteriorFloorSystem"
+                                  type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FoundationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CriticalITSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PlugLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType" maxOccurs="unbounded"/>
+                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ProcessLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType" maxOccurs="unbounded"/>
+                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ConveyanceSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="OnsiteStorageTransmissionGenerationSystems" minOccurs="0">
+                          <xs:element name="OnsiteStorageTransmissionGenerationSystems"
+                            minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="OnsiteStorageTransmissionGenerationSystem" type="auc:OnsiteStorageTransmissionGenerationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="OnsiteStorageTransmissionGenerationSystem"
+                                  type="auc:OnsiteStorageTransmissionGenerationSystemType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -241,7 +270,8 @@
                           <xs:element name="WaterUses" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WaterUse" type="auc:WaterUseType" maxOccurs="unbounded"/>
+                                <xs:element name="WaterUse" type="auc:WaterUseType"
+                                  maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -254,12 +284,14 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="AirInfiltrationNotes" type="xs:string" minOccurs="0">
+                                      <xs:element name="AirInfiltrationNotes" type="xs:string"
+                                        minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="Tightness" type="auc:Tightness" minOccurs="0">
+                                      <xs:element name="Tightness" type="auc:Tightness"
+                                        minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Description of the infiltration characteristics for an opaque surface, fenestration unit, a thermal zone.</xs:documentation>
                                         </xs:annotation>
@@ -324,15 +356,19 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="WaterInfiltrationNotes" type="xs:string" minOccurs="0">
+                                      <xs:element name="WaterInfiltrationNotes" type="xs:string"
+                                        minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages" minOccurs="0">
+                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages"
+                                        minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element name="LocationsOfExteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element
+                                              name="LocationsOfExteriorWaterIntrusionDamage"
+                                              minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the outside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -352,10 +388,13 @@
                                           </xs:sequence>
                                         </xs:complexType>
                                       </xs:element>
-                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages" minOccurs="0">
+                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages"
+                                        minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element name="LocationsOfInteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element
+                                              name="LocationsOfInteriorWaterIntrusionDamage"
+                                              minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the inside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -385,7 +424,8 @@
                     <xs:element name="Schedules" minOccurs="0">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"/>
+                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"
+                          />
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
@@ -723,12 +763,14 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="OverallWindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallWindowToWallRatio" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall window to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="OverallDoorToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallDoorToWallRatio" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall door to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -788,8 +830,10 @@
                         <xs:enumeration value="ENERGY STAR"/>
                         <xs:enumeration value="ENERGY STAR Certified Homes"/>
                         <xs:enumeration value="LEED"/>
-                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
-                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
+                        <xs:enumeration
+                          value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
+                        <xs:enumeration
+                          value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
                         <xs:enumeration value="Passive House"/>
                         <xs:enumeration value="Living Building Challenge"/>
                         <xs:enumeration value="Green Globes"/>
@@ -1082,7 +1126,8 @@
                                 <xs:element name="WallIDs">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WallID" minOccurs="0" maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WallID" minOccurs="0"
+                                        maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1092,7 +1137,8 @@
                                 <xs:element name="WindowIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WindowID" minOccurs="0" maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WindowID" minOccurs="0"
+                                        maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1102,7 +1148,8 @@
                                 <xs:element name="DoorIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:DoorID" minOccurs="0" maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:DoorID" minOccurs="0"
+                                        maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1156,7 +1203,8 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition" minOccurs="0">
+                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition"
+                                      minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Description of the roof's condition.</xs:documentation>
                                       </xs:annotation>
@@ -1167,7 +1215,8 @@
                                       </xs:annotation>
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="SkylightID" minOccurs="0" maxOccurs="unbounded">
+                                          <xs:element name="SkylightID" minOccurs="0"
+                                            maxOccurs="unbounded">
                                             <xs:annotation>
                                               <xs:documentation>ID number of the skylight type associated with this side of the section.</xs:documentation>
                                             </xs:annotation>
@@ -1175,18 +1224,19 @@
                                               <xs:sequence>
                                                 <xs:element name="PercentSkylightArea" minOccurs="0">
                                                   <xs:annotation>
-                                                    <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
+                                                  <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
                                                   </xs:annotation>
                                                   <xs:complexType>
-                                                    <xs:simpleContent>
-                                                      <xs:extension base="xs:decimal">
-                                                        <xs:attribute ref="auc:Source"/>
-                                                      </xs:extension>
-                                                    </xs:simpleContent>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:decimal">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
-                                              <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
+                                              <xs:attribute name="IDref" type="xs:IDREF"
+                                                use="required"/>
                                             </xs:complexType>
                                           </xs:element>
                                         </xs:sequence>
@@ -1421,7 +1471,8 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ThermalZone" type="auc:ThermalZoneType" maxOccurs="unbounded"/>
+                        <xs:element name="ThermalZone" type="auc:ThermalZoneType"
+                          maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
@@ -2049,7 +2100,8 @@
                         <xs:element name="StandardPractice" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="StandardPracticeDescription" type="xs:string" minOccurs="0">
+                              <xs:element name="StandardPracticeDescription" type="xs:string"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the standard practice represented by this scenario (e.g., builder standard practice, portfolio average, local practice).</xs:documentation>
                                 </xs:annotation>
@@ -2061,7 +2113,8 @@
                         <xs:element name="Other" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="OtherBenchmarkDescription" type="xs:string" minOccurs="0">
+                              <xs:element name="OtherBenchmarkDescription" type="xs:string"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the benchmark scenario (e.g., original design, building next door).</xs:documentation>
                                 </xs:annotation>
@@ -2117,6 +2170,30 @@
                   <xs:element ref="auc:AnnualPeakElectricityReduction" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
+                  <xs:element minOccurs="0" name="AnnualSavingsAverageCarbonEmissions">
+                    <xs:annotation>
+                      <xs:documentation>Average carbon emissions savings per year. (kg CO2e)</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:decimal">
+                          <xs:attribute ref="auc:Source"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
+                    <xs:annotation>
+                      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e)</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:decimal">
+                          <xs:attribute ref="auc:Source"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -2170,7 +2247,8 @@
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(d)</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh" minOccurs="0">
+                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh"
+                          minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(e)</xs:documentation>
                           </xs:annotation>
@@ -2199,6 +2277,30 @@
                   <xs:element ref="auc:AnnualDemandSavingsCost" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
+                  <xs:element minOccurs="0" name="AnnualSavingsAverageCarbonEmissions">
+                    <xs:annotation>
+                      <xs:documentation>Average carbon emissions savings per year. (kg CO2e)</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:decimal">
+                          <xs:attribute ref="auc:Source"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
+                    <xs:annotation>
+                      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e)</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:decimal">
+                          <xs:attribute ref="auc:Source"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
                   <xs:element name="ImplementationPeriod" type="xs:integer" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Total period of time necessary to implement all measures in the package. (months)</xs:documentation>
@@ -2311,6 +2413,30 @@
                   <xs:element ref="auc:AnnualPeakElectricityReduction" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
+                  <xs:element minOccurs="0" name="AnnualSavingsAverageCarbonEmissions">
+                    <xs:annotation>
+                      <xs:documentation>Average carbon emissions savings per year. (kg CO2e)</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:decimal">
+                          <xs:attribute ref="auc:Source"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
+                    <xs:annotation>
+                      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e)</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:simpleContent>
+                        <xs:extension base="xs:decimal">
+                          <xs:attribute ref="auc:Source"/>
+                        </xs:extension>
+                      </xs:simpleContent>
+                    </xs:complexType>
+                  </xs:element>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -2392,7 +2518,8 @@
       <xs:element name="AllResourceTotals" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType" maxOccurs="unbounded"/>
+            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType"
+              maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -2462,16 +2589,22 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0"
+                                      maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                          <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
+                                          <xs:element ref="auc:DemandRatchetPercentage"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
                                           <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
                                           <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
@@ -2495,52 +2628,69 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0"
+                                      maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
+                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
+                                            minOccurs="0"/>
                                           <xs:element name="TimeOfUsePeriods" minOccurs="0">
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="TimeOfUsePeriod" minOccurs="0" maxOccurs="unbounded">
+                                                <xs:element name="TimeOfUsePeriod" minOccurs="0"
+                                                  maxOccurs="unbounded">
                                                   <xs:complexType>
-                                                    <xs:sequence>
-                                                      <xs:element name="TOUNumberForRateStructure" type="xs:int" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The number associated with the TOU period.</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableStartTimeForEnergyRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableEndTimeForEnergyRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableStartTimeForDemandRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element name="ApplicableEndTimeForDemandRate" type="xs:time" minOccurs="0">
-                                                        <xs:annotation>
-                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                        </xs:annotation>
-                                                      </xs:element>
-                                                      <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                      <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
-                                                      <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
-                                                      <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
-                                                      <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                      <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
-                                                    </xs:sequence>
+                                                  <xs:sequence>
+                                                  <xs:element name="TOUNumberForRateStructure"
+                                                  type="xs:int" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The number associated with the TOU period.</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element
+                                                  name="ApplicableStartTimeForEnergyRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element name="ApplicableEndTimeForEnergyRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element
+                                                  name="ApplicableStartTimeForDemandRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element name="ApplicableEndTimeForDemandRate"
+                                                  type="xs:time" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                  </xs:annotation>
+                                                  </xs:element>
+                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                  <xs:element ref="auc:ElectricDemandRate"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:EnergyRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRatchetPercentage"
+                                                  minOccurs="0"/>
+                                                  </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
@@ -2568,66 +2718,80 @@
                                     <xs:element name="RatePeriods" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
+                                          <xs:element name="RatePeriod" minOccurs="0"
+                                            maxOccurs="unbounded">
                                             <xs:complexType>
                                               <xs:sequence>
                                                 <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
+                                                <xs:element
+                                                  ref="auc:ApplicableStartDateForEnergyRate"
+                                                  minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate"
+                                                  minOccurs="0"/>
+                                                <xs:element
+                                                  ref="auc:ApplicableStartDateForDemandRate"
+                                                  minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForDemandRate"
+                                                  minOccurs="0"/>
                                                 <xs:element name="RateTiers" minOccurs="0">
                                                   <xs:complexType>
-                                                    <xs:sequence>
-                                                      <xs:element name="RateTier" minOccurs="0" maxOccurs="unbounded">
-                                                        <xs:complexType>
-                                                          <xs:sequence>
-                                                            <xs:element name="ConsumptionEnergyTierDesignation" minOccurs="0">
-                                                            <xs:annotation>
-                                                            <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
-                                                            </xs:annotation>
-                                                            <xs:complexType>
-                                                            <xs:simpleContent>
-                                                            <xs:extension base="xs:integer">
-                                                            <xs:attribute ref="auc:Source"/>
-                                                            </xs:extension>
-                                                            </xs:simpleContent>
-                                                            </xs:complexType>
-                                                            </xs:element>
-                                                            <xs:element name="MaxkWhUsage" minOccurs="0">
-                                                            <xs:annotation>
-                                                            <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
-                                                            </xs:annotation>
-                                                            <xs:complexType>
-                                                            <xs:simpleContent>
-                                                            <xs:extension base="xs:decimal">
-                                                            <xs:attribute ref="auc:Source"/>
-                                                            </xs:extension>
-                                                            </xs:simpleContent>
-                                                            </xs:complexType>
-                                                            </xs:element>
-                                                            <xs:element name="MaxkWUsage" minOccurs="0">
-                                                            <xs:annotation>
-                                                            <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
-                                                            </xs:annotation>
-                                                            <xs:complexType>
-                                                            <xs:simpleContent>
-                                                            <xs:extension base="xs:decimal">
-                                                            <xs:attribute ref="auc:Source"/>
-                                                            </xs:extension>
-                                                            </xs:simpleContent>
-                                                            </xs:complexType>
-                                                            </xs:element>
-                                                            <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                            <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
-                                                            <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
-                                                            <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
-                                                            <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                            <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
-                                                          </xs:sequence>
-                                                        </xs:complexType>
-                                                      </xs:element>
-                                                    </xs:sequence>
+                                                  <xs:sequence>
+                                                  <xs:element name="RateTier" minOccurs="0"
+                                                  maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                  <xs:sequence>
+                                                  <xs:element
+                                                  name="ConsumptionEnergyTierDesignation"
+                                                  minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
+                                                  </xs:annotation>
+                                                  <xs:complexType>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:integer">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element name="MaxkWhUsage" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
+                                                  </xs:annotation>
+                                                  <xs:complexType>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:decimal">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element name="MaxkWUsage" minOccurs="0">
+                                                  <xs:annotation>
+                                                  <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
+                                                  </xs:annotation>
+                                                  <xs:complexType>
+                                                  <xs:simpleContent>
+                                                  <xs:extension base="xs:decimal">
+                                                  <xs:attribute ref="auc:Source"/>
+                                                  </xs:extension>
+                                                  </xs:simpleContent>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                  <xs:element ref="auc:ElectricDemandRate"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:EnergyRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRateAdjustment"
+                                                  minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                  <xs:element ref="auc:DemandRatchetPercentage"
+                                                  minOccurs="0"/>
+                                                  </xs:sequence>
+                                                  </xs:complexType>
+                                                  </xs:element>
+                                                  </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                                 <xs:element ref="auc:EnergySellRate" minOccurs="0"/>
@@ -3123,6 +3287,20 @@
                       </xs:simpleContent>
                     </xs:complexType>
                   </xs:element>
+                  <xs:element minOccurs="0" name="EmissionsLinkedTimeSeriesIDs">
+                    <xs:annotation>
+                      <xs:documentation>Links to all time series data used to calculate the GHGEmissions</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element maxOccurs="unbounded" minOccurs="1" name="LinkedTimeSeriesID">
+                          <xs:complexType>
+                            <xs:attribute name="IDref" type="xs:IDREF"/>
+                          </xs:complexType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
@@ -3382,6 +3560,30 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
+      <xs:element minOccurs="0" name="AnnualAverageCarbonEmissions">
+        <xs:annotation>
+          <xs:documentation>Annual Average Carbon Emissions. (kg CO2e)</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:decimal">
+              <xs:attribute ref="auc:Source"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="AnnualMarginalCarbonEmissions">
+        <xs:annotation>
+          <xs:documentation>Annual Marginal Carbon Emissions. (kg CO2e)</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:decimal">
+              <xs:attribute ref="auc:Source"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
     </xs:sequence>
     <xs:attribute name="ID" type="xs:ID" use="required"/>
   </xs:complexType>
@@ -3440,6 +3642,7 @@
             <xs:enumeration value="Frequency"/>
             <xs:enumeration value="Power"/>
             <xs:enumeration value="Power Factor"/>
+            <xs:enumeration value="Emissions"/>
             <xs:enumeration value="Energy"/>
             <xs:enumeration value="Voltage"/>
             <xs:enumeration value="Voltage Angle"/>
@@ -3581,7 +3784,8 @@
                   <xs:element name="Replacement" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemReplaced" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemReplaced" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems replaced by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3589,7 +3793,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element name="AlternativeSystemReplacement" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemReplacement" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would replace the existing systems.</xs:documentation>
                           </xs:annotation>
@@ -3597,7 +3802,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3611,7 +3817,8 @@
                   <xs:element name="ModificationRetrocommissioning" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemAffected" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemAffected" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems affected by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3627,7 +3834,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3641,7 +3849,8 @@
                   <xs:element name="Addition" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="AlternativeSystemAdded" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemAdded" minOccurs="0"
+                          maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would be added as part of the measure.</xs:documentation>
                           </xs:annotation>
@@ -3649,7 +3858,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3671,7 +3881,8 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
+                          maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3750,7 +3961,8 @@
                               <xs:enumeration value="Convert system from steam to hot water"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Convert to Cleaner Fuels"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -3779,7 +3991,8 @@
                               <xs:enumeration value="Add or replace cooling tower"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3803,7 +4016,8 @@
                               <xs:enumeration value="Add or upgrade BAS/EMS/EMCS"/>
                               <xs:enumeration value="Add or upgrade controls"/>
                               <xs:enumeration value="Convert pneumatic controls to DDC"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3835,7 +4049,8 @@
                               <xs:enumeration value="Replace package units"/>
                               <xs:enumeration value="Replace packaged terminal units"/>
                               <xs:enumeration value="Install passive solar heating"/>
-                              <xs:enumeration value="Replace AC and heating units with ground coupled heat pump systems"/>
+                              <xs:enumeration
+                                value="Replace AC and heating units with ground coupled heat pump systems"/>
                               <xs:enumeration value="Add enhanced dehumidification"/>
                               <xs:enumeration value="Install solar ventilation preheating system"/>
                               <xs:enumeration value="Add or repair economizer"/>
@@ -3850,7 +4065,8 @@
                               <xs:enumeration value="Install or Upgrade Master Venting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other heating"/>
                               <xs:enumeration value="Other cooling"/>
                               <xs:enumeration value="Other ventilation"/>
@@ -3878,8 +4094,10 @@
                               <xs:enumeration value="Retrofit with T-5"/>
                               <xs:enumeration value="Retrofit with T-8"/>
                               <xs:enumeration value="Install spectrally enhanced lighting"/>
-                              <xs:enumeration value="Retrofit with fiber optic lighting technologies"/>
-                              <xs:enumeration value="Retrofit with light emitting diode technologies"/>
+                              <xs:enumeration
+                                value="Retrofit with fiber optic lighting technologies"/>
+                              <xs:enumeration
+                                value="Retrofit with light emitting diode technologies"/>
                               <xs:enumeration value="Add daylight controls"/>
                               <xs:enumeration value="Add occupancy sensors"/>
                               <xs:enumeration value="Install photocell control"/>
@@ -3889,7 +4107,8 @@
                               <xs:enumeration value="Upgrade exterior lighting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3947,8 +4166,10 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Add pipe insulation"/>
                               <xs:enumeration value="Repair and/or replace steam traps"/>
-                              <xs:enumeration value="Retrofit and replace chiller plant pumping, piping, and controls"/>
-                              <xs:enumeration value="Repair or replace existing condensate return systems or install new condensate return systems"/>
+                              <xs:enumeration
+                                value="Retrofit and replace chiller plant pumping, piping, and controls"/>
+                              <xs:enumeration
+                                value="Repair or replace existing condensate return systems or install new condensate return systems"/>
                               <xs:enumeration value="Add recirculating pumps"/>
                               <xs:enumeration value="Replace or upgrade water heater"/>
                               <xs:enumeration value="Add energy recovery"/>
@@ -3961,7 +4182,8 @@
                               <xs:enumeration value="Install steam condensate heat recovery"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3986,7 +4208,8 @@
                               <xs:enumeration value="Upgrade motors"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4011,7 +4234,8 @@
                               <xs:enumeration value="Add VSD motor controller"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4031,12 +4255,14 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration value="Replace ice/refrigeration equipment with high efficiency units"/>
+                              <xs:enumeration
+                                value="Replace ice/refrigeration equipment with high efficiency units"/>
                               <xs:enumeration value="Replace air-cooled ice/refrigeration equipment"/>
                               <xs:enumeration value="Replace refrigerators"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4062,7 +4288,8 @@
                               <xs:enumeration value="Convert fuels"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4082,14 +4309,17 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
+                              <xs:enumeration
+                                value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
                               <xs:enumeration value="Install photovoltaic system"/>
                               <xs:enumeration value="Install wind energy system"/>
-                              <xs:enumeration value="Install wood waste or other organic waste stream heating or power plant"/>
+                              <xs:enumeration
+                                value="Install wood waste or other organic waste stream heating or power plant"/>
                               <xs:enumeration value="Install electrical storage"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4115,7 +4345,8 @@
                               <xs:enumeration value="Install gas distribution systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4149,7 +4380,8 @@
                               <xs:enumeration value="Install tankless water heaters"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4175,7 +4407,8 @@
                               <xs:enumeration value="Implement water efficient irrigation"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4197,7 +4430,8 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Install thermal energy storage"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4218,8 +4452,10 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Change to more favorable rate schedule"/>
-                              <xs:enumeration value="Energy cost reduction through rate adjustments - uncategorized"/>
-                              <xs:enumeration value="Energy service billing and meter auditing recommendations"/>
+                              <xs:enumeration
+                                value="Energy cost reduction through rate adjustments - uncategorized"/>
+                              <xs:enumeration
+                                value="Energy service billing and meter auditing recommendations"/>
                               <xs:enumeration value="Change to lower energy cost supplier(s)"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -4241,10 +4477,12 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Implement industrial process improvements"/>
-                              <xs:enumeration value="Implement production and/or manufacturing improvements"/>
+                              <xs:enumeration
+                                value="Implement production and/or manufacturing improvements"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4267,7 +4505,8 @@
                               <xs:enumeration value="Install advanced metering systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4295,7 +4534,8 @@
                               <xs:enumeration value="Replace washing machines"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4322,7 +4562,8 @@
                               <xs:enumeration value="Upgrade servers"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration
+                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4802,7 +5043,8 @@
               </xs:annotation>
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType" minOccurs="0">
+                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Qualification of auditor responsible for the audit report.</xs:documentation>
                     </xs:annotation>
@@ -4830,7 +5072,8 @@
                       <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="AuditTeamMemberCertificationType" type="auc:AuditorQualificationType" minOccurs="0">
+                  <xs:element name="AuditTeamMemberCertificationType"
+                    type="auc:AuditorQualificationType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Type of certification held by an auditor team member.</xs:documentation>
                     </xs:annotation>
@@ -4901,7 +5144,8 @@
             <xs:element name="HeatingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0" maxOccurs="unbounded">
+                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0"
+                    maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of central heating system, defined as any source of heating energy separate from the zone being heated. Local heating systems (such as packaged systems and fan-coils) are recorded in a separate data field.</xs:documentation>
                     </xs:annotation>
@@ -4912,7 +5156,8 @@
             <xs:element name="CoolingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0" maxOccurs="unbounded">
+                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0"
+                    maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of cooling plant. Zonal cooling is recorded in a separate data field. Use of fans or blowers by themselves without chilled air or water is not included in this definition of cooling. Stand-alone dehumidifiers are also not included.</xs:documentation>
                     </xs:annotation>
@@ -4923,7 +5168,8 @@
             <xs:element name="CondenserPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0" maxOccurs="unbounded">
+                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0"
+                    maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of condenser used for refrigerant-based systems.</xs:documentation>
                     </xs:annotation>
@@ -5021,7 +5267,8 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature" minOccurs="0">
+                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature"
+                                      minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Minimum outside temperature at which the heat pump can operate. (°F)</xs:documentation>
                                       </xs:annotation>
@@ -5033,7 +5280,8 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes" minOccurs="0">
+                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes"
+                                      minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Backup fuel used by the heat pump.</xs:documentation>
                                       </xs:annotation>
@@ -5112,14 +5360,16 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
+                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition"
+                          minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for HeatingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType"
+                                maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>Control for HeatingSource.</xs:documentation>
                                 </xs:annotation>
@@ -5172,13 +5422,16 @@
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Split DX air conditioner"/>
-                                          <xs:enumeration value="Packaged terminal air conditioner (PTAC)"/>
+                                          <xs:enumeration
+                                            value="Packaged terminal air conditioner (PTAC)"/>
                                           <xs:enumeration value="Split heat pump"/>
                                           <xs:enumeration value="Packaged terminal heat pump (PTHP)"/>
                                           <xs:enumeration value="Variable refrigerant flow"/>
-                                          <xs:enumeration value="Packaged/unitary direct expansion/RTU"/>
+                                          <xs:enumeration
+                                            value="Packaged/unitary direct expansion/RTU"/>
                                           <xs:enumeration value="Packaged/unitary heat pump"/>
-                                          <xs:enumeration value="Single package vertical air conditioner"/>
+                                          <xs:enumeration
+                                            value="Single package vertical air conditioner"/>
                                           <xs:enumeration value="Single package vertical heat pump"/>
                                           <xs:enumeration value="Other"/>
                                           <xs:enumeration value="Unknown"/>
@@ -5262,14 +5515,16 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
+                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition"
+                          minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for CoolingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType"
+                                maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>CoolingSource control.</xs:documentation>
                                 </xs:annotation>
@@ -5324,7 +5579,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5342,7 +5598,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness"
+                                            minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5377,10 +5634,14 @@
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="CAV terminal box no reheat"/>
                                           <xs:enumeration value="CAV terminal box with reheat"/>
-                                          <xs:enumeration value="VAV terminal box fan powered no reheat"/>
-                                          <xs:enumeration value="VAV terminal box fan powered with reheat"/>
-                                          <xs:enumeration value="VAV terminal box not fan powered no reheat"/>
-                                          <xs:enumeration value="VAV terminal box not fan powered with reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box fan powered no reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box fan powered with reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box not fan powered no reheat"/>
+                                          <xs:enumeration
+                                            value="VAV terminal box not fan powered with reheat"/>
                                           <xs:enumeration value="Powered induction unit"/>
                                           <xs:enumeration value="Automatically controlled register"/>
                                           <xs:enumeration value="Manually controlled register"/>
@@ -5461,7 +5722,8 @@
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType"
+                                maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>DeliverySystem control.</xs:documentation>
                                 </xs:annotation>
@@ -5475,7 +5737,8 @@
                         <xs:element ref="auc:ModelNumber" minOccurs="0"/>
                         <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
                         <xs:element ref="auc:Quantity" minOccurs="0"/>
-                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition" minOccurs="0"/>
+                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition"
+                          minOccurs="0"/>
                       </xs:sequence>
                       <xs:attribute name="ID" type="xs:ID" use="required"/>
                       <xs:attribute ref="auc:Status">
@@ -5501,7 +5764,8 @@
       <xs:element name="OtherHVACSystems" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"/>
+            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"
+            />
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -5787,7 +6051,8 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of total duct leakage that is on the supply side. Remainder is assumed to be on the return side. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -6192,7 +6457,8 @@
               <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
               <xs:element ref="auc:MinimumPartLoadRatio" minOccurs="0"/>
               <xs:element ref="auc:RatedCoolingSensibleHeatRatio" minOccurs="0"/>
-              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0"
+                type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                 <xs:annotation>
                   <xs:documentation>The part load ratio of the chiller below which hot gas bypass (HGBP) operates. (0-1) (fraction)</xs:documentation>
                 </xs:annotation>
@@ -7091,12 +7357,14 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="MinimumDimmingLightFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingLightFraction" minOccurs="0"
+              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>Minimum light output of controlled lighting when fully dimmed. Minimum light fraction = (Minimum light output) / (Rated light output). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0"
+              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>The minimum power fraction when controlled lighting is fully dimmed. Minimum power fraction = (Minimum power) / (Full rated power). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
@@ -7341,7 +7609,9 @@
                                     <xs:element name="HeatPump" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatedHeatPumpSensibleHeatRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                                          <xs:element name="RatedHeatPumpSensibleHeatRatio"
+                                            minOccurs="0"
+                                            type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                                             <xs:annotation>
                                               <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
                                             </xs:annotation>
@@ -7380,7 +7650,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorArea" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorArea"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Area of solar collector exposed to solar radiation. (ft2)</xs:documentation>
                                             </xs:annotation>
@@ -7392,7 +7663,8 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorLoopType" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorLoopType"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Heat transfer medium and controls used for the solar collector loop.</xs:documentation>
                                             </xs:annotation>
@@ -7408,7 +7680,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorType" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorType"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Type of solar energy collector used in a solar hot water or space heating system.</xs:documentation>
                                             </xs:annotation>
@@ -7425,7 +7698,8 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorAzimuth" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorAzimuth"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Degrees clockwise from North. For a premises, it is the azimuth of the front facing element. It can also be applied to envelope components, such as walls, windows (fenestration), as well as onsite generation technologies, such as photovoltaic panels. (0 - 360) (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7437,7 +7711,8 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorTilt" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorTilt"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>The angle from a horizontal surface; can be applied to an opaque surface, a fenestration unit, a solar panel, etc. (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7449,7 +7724,8 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemStorageVolume" minOccurs="0">
+                                          <xs:element name="SolarThermalSystemStorageVolume"
+                                            minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Volume of any separate solar energy storage tank, not the primary service hot water tank. (gal)</xs:documentation>
                                             </xs:annotation>
@@ -7467,9 +7743,11 @@
                                             </xs:annotation>
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
+                                                <xs:element name="Control"
+                                                  type="auc:ControlGeneralType"
+                                                  maxOccurs="unbounded">
                                                   <xs:annotation>
-                                                    <xs:documentation>Solar hot water control.</xs:documentation>
+                                                  <xs:documentation>Solar hot water control.</xs:documentation>
                                                   </xs:annotation>
                                                 </xs:element>
                                               </xs:sequence>
@@ -8651,7 +8929,8 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="FanPowerMinimumRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="FanPowerMinimumRatio" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>The minimum power draw of the fan, expressed as a ratio of the full load fan power. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -9071,7 +9350,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
+                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9102,7 +9382,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition"
+                    minOccurs="0"/>
                   <xs:element name="WallInsulationLocation" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Whether wall insulation is on the inside or outside of the wall.</xs:documentation>
@@ -9287,7 +9568,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
+                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9318,7 +9600,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition"
+                    minOccurs="0"/>
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
@@ -9465,7 +9748,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
+                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType"
+                    minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9496,7 +9780,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition"
+                    minOccurs="0"/>
                   <xs:element name="RoofInsulationRValue" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Insulation R Value of the layer. (hr-ft2-F/Btu)</xs:documentation>
@@ -9993,7 +10278,8 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0"
+                    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                     <xs:annotation>
                       <xs:documentation>Fraction of door area that is glazed. (0-1) (fraction)</xs:documentation>
                     </xs:annotation>
@@ -10332,7 +10618,8 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="FloorInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
+                                    <xs:element name="FloorInsulationCondition"
+                                      type="auc:InsulationCondition" minOccurs="0"/>
                                     <xs:element name="FloorRValue" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>(Also known as thermal resistance), quantity determined by the temperature difference, at steady state, between two defined surfaces of a material or construction that induces a unit heat flow rate through unit area (R = ΔT/q). R-value is the reciprocal of thermal conductance. A unit of thermal resistance used for comparing insulating values of different materials, for the specific thickness of the material. The higher the R-value number, a material, the greater its insulating properties and the slower the heat flow through it. This R-value does not include the interior and exterior air film coefficients. (hr-ft2-F/Btu)</xs:documentation>
@@ -10401,11 +10688,14 @@
                                   <xs:sequence>
                                     <xs:element ref="auc:FoundationWallConstruction" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationHeightAboveGrade" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationThickness" minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationThickness"
+                                      minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallRValue" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallUFactor" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationContinuity" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationCondition" minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationContinuity"
+                                      minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationCondition"
+                                      minOccurs="0"/>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -10722,7 +11012,8 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:WeightedAverageLoad" minOccurs="0"/>
-      <xs:element name="HeatGainFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="HeatGainFraction" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of installed power that results in heat gain to the space. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -10916,7 +11207,8 @@
                         <xs:element name="PV" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray" minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Number of modules in each array of a photovoltaic system.</xs:documentation>
                                 </xs:annotation>
@@ -10976,7 +11268,8 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin" minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Minimum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -10988,7 +11281,8 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax" minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Maximum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -11079,7 +11373,8 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="OutputResourceType" type="auc:FuelTypes" minOccurs="0">
+                              <xs:element name="OutputResourceType" type="auc:FuelTypes"
+                                minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Resource or fuel produced by the generation system and used as energy on the premises.</xs:documentation>
                                 </xs:annotation>
@@ -11350,7 +11645,8 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0"
+        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Average fraction of water use for this application that is drawn from the hot water system. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -13624,37 +13920,59 @@
       <xs:enumeration value="Professional Engineer (PE)"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Certified Member Agency"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Test and Balance Technician"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Demand Side Manager (CDSM)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
       <xs:enumeration value="Association of Energy Engineers Energy Efficiency Practitioner (EEP)"/>
       <xs:enumeration value="Association of Energy Engineers Renewable Energy Professional (REP)"/>
-      <xs:enumeration value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
-      <xs:enumeration value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Manager (CEM)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Auditor (CEA)"/>
-      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
+      <xs:enumeration
+        value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 1"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 2"/>
       <xs:enumeration value="Building Performance Institute (BPI) Certification"/>
       <xs:enumeration value="Building Performance Institute (BPI): Building Analyst (BA)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
-      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
+      <xs:enumeration
+        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
       <xs:enumeration value="Building Performance Institute (BPI): Multifamily Building Analyst"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) Certification"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) - Home Partner"/>
@@ -13864,7 +14182,8 @@
   </xs:complexType>
   <xs:complexType name="FanBasedType">
     <xs:sequence>
-      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType" minOccurs="0"/>
+      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType"
+        minOccurs="0"/>
       <xs:element name="AirSideEconomizer" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
@@ -14256,7 +14575,8 @@
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType" minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType"
+              minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Daylighting control strategy.</xs:documentation>
               </xs:annotation>
@@ -14339,7 +14659,8 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType" minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType"
+                minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
                 </xs:annotation>
@@ -14353,7 +14674,8 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType" minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType"
+                minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
                 </xs:annotation>
@@ -14948,7 +15270,8 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="auc:FenestrationArea" minOccurs="0"/>
-        <xs:element name="WindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+        <xs:element name="WindowToWallRatio" minOccurs="0"
+          type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
           <xs:annotation>
             <xs:documentation>Ratio of total window area to total wall area. (0-1) (fraction)</xs:documentation>
           </xs:annotation>
@@ -14995,26 +15318,32 @@
                         <xs:element name="ResponseVariable" minOccurs="1" maxOccurs="1">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ResponseVariableName" type="auc:FuelTypes" minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType" minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType" minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableName" type="auc:FuelTypes"
+                                minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType"
+                                minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType"
+                                minOccurs="1" maxOccurs="1"/>
                             </xs:sequence>
                           </xs:complexType>
                         </xs:element>
                         <xs:element name="ExplanatoryVariables">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ExplanatoryVariable" minOccurs="1" maxOccurs="unbounded">
+                              <xs:element name="ExplanatoryVariable" minOccurs="1"
+                                maxOccurs="unbounded">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="ExplanatoryVariableName" minOccurs="1" maxOccurs="1">
+                                    <xs:element name="ExplanatoryVariableName" minOccurs="1"
+                                      maxOccurs="1">
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Drybulb Temperature"/>
                                           <xs:enumeration value="Wetbulb Temperature"/>
                                           <xs:enumeration value="Relative Humidity"/>
                                           <xs:enumeration value="Global Horizontal Irradiance (GHI)"/>
-                                          <xs:enumeration value="Diffuse Horizontal Irradiance (DHI)"/>
+                                          <xs:enumeration
+                                            value="Diffuse Horizontal Irradiance (DHI)"/>
                                           <xs:enumeration value="Direct Normal Irradiance (DNI)"/>
                                           <xs:enumeration value="Hour of week">
                                             <xs:annotation>
@@ -15080,7 +15409,8 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"> </xs:element>
+                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"
+                                      > </xs:element>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -15110,7 +15440,8 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0"
+                                maxOccurs="1">
                                 <xs:annotation>
                                   <xs:documentation>The 'y-intercept' value.  In Figure D-1 (a), this is Eb.  In Figure D-1 (a)-(g), this is C.</xs:documentation>
                                 </xs:annotation>
@@ -15226,27 +15557,32 @@
                   <xs:element name="SummaryInformation" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of periods in the Baseline period data.  It is denoted as "n" throughout B4.  A "period" refers to a measurement of the ResponseVariable.  For example, 24 hours worth of data collected at hourly intervals would have 24 "periods".</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of parameters in the model.  It is denoted as "p" throughout B4.  The number of parameters is not necessarily equal to the number of auc:ExplanatoryVariable elements.  For example, a 5 parameter change point model has 5 parameters, even though there is only a single ExplanatoryVariable (likely Drybulb Temperature).  In certain cases, this is used in the calculation of the degrees of freedom for the t-statistic.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>Degrees of Freedom as used in the context of a t-distribution.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the actual energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits. See: the Retrofit Isolation Approach (G-14 4.1.1) and Whole Facility Approach (G-14 4.1.2) of ASHRAE Guideline 14-2018.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0"
+                          maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the model estimated energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                           </xs:annotation>
@@ -15305,22 +15641,26 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The beginning of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The end of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the actual energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the model estimated energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
@@ -15330,32 +15670,38 @@
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. As documented in Annex B4.1g and the result of Equation B-14 of ASHRAE Guideline 14-2018 (E_save,m), this value represents the 'actual savings'.  It is calculated via the following: E_save,m = Ehat_base,m - E_meas,m.  In BuildingSync terms, the AvoidedEnergyUse = ComparisonPeriodAggregateModeledEnergyUse - ComparisonPeriodAggregateActualEnergyUse.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The savings uncertainty represented as a decimal.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The confidence level represented as a decimal between zero and one.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse"
+                    type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized baseline energy use", or the predicted energy consumption using the Baseline model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse"
+                    type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized postretrofit energy use", or the predicted energy consumption using the Reporting (or postretrofit) model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "normalized savings is then defined as the normalized baseline energy use minus the normalized postretrofit energy use".  The "normalized baseline energy use" referred to in G-14 is captured by the auc:BaselinePeriodCalculatedEnergyUseStandardConditions element, while the "normalized postretrofit energy use" is captured by the auc:ReportingPeriodCalculatedEnergyUseStandardConditions element.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0"
+                    maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. Used to capture the modeled timeseries data associated with the comparison period.</xs:documentation>
                     </xs:annotation>
@@ -15365,7 +15711,8 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the baseline period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15375,7 +15722,8 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData"
+                    minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the reporting period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15429,7 +15777,9 @@
     <xs:annotation>
       <xs:documentation>Enumeration for different potential units.</xs:documentation>
     </xs:annotation>
-    <xs:union memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"/>
+    <xs:union
+      memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"
+    />
   </xs:simpleType>
   <xs:simpleType name="DimensionlessUnitsType">
     <xs:union memberTypes="auc:OtherUnitsType auc:DimensionlessUnitsBaseType"/>
@@ -15513,10 +15863,17 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="ActiveDehumidification" type="xs:boolean">
+  <xs:element name="ActiveDehumidification">
     <xs:annotation>
       <xs:documentation>True if an active dehumidification system is available (in addition to the dehumidification that takes place during normal direct expansion (DX) cooling operation).</xs:documentation>
     </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
   </xs:element>
   <xs:element name="AnnualCoolingEfficiencyValue">
     <xs:annotation>
@@ -15834,7 +16191,7 @@
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base="xs:decimal">
-        <xs:attribute ref="auc:Source"/>
+          <xs:attribute ref="auc:Source"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
@@ -15929,7 +16286,7 @@
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base="xs:decimal">
-        <xs:attribute ref="auc:Source"/>
+          <xs:attribute ref="auc:Source"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>
@@ -16107,7 +16464,8 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="HeatingStageCapacityFraction" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="HeatingStageCapacityFraction"
+    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>Average capacity of each heating stage, at Air-Conditioning, Heating, and Refrigeration Institute (AHRI) rated conditions, expressed as a fraction of total capacity. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -16451,7 +16809,8 @@
       <xs:documentation>The name or title of rate period.  This is intended to capture the seasonal changes in rates.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RatedCoolingSensibleHeatRatio" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="RatedCoolingSensibleHeatRatio"
+    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -16744,7 +17103,8 @@
   <xs:element name="SpatialUnits">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1"
+          maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -2117,8 +2117,8 @@
                   <xs:element ref="auc:AnnualPeakElectricityReduction" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
-                  <xs:element ref="auc:AnnualSavingsAverageCarbonEmissions" minOccurs="0"/>
-                  <xs:element ref="auc:AnnualSavingsMarginalCarbonEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsAverageGHGEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsMarginalGHGEmissions" minOccurs="0"/>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -2201,8 +2201,8 @@
                   <xs:element ref="auc:AnnualDemandSavingsCost" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
-                  <xs:element ref="auc:AnnualSavingsAverageCarbonEmissions" minOccurs="0"/>
-                  <xs:element ref="auc:AnnualSavingsMarginalCarbonEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsAverageGHGEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsMarginalGHGEmissions" minOccurs="0"/>
                   <xs:element name="ImplementationPeriod" type="xs:integer" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Total period of time necessary to implement all measures in the package. (months)</xs:documentation>
@@ -2315,8 +2315,8 @@
                   <xs:element ref="auc:AnnualPeakElectricityReduction" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterSavings" minOccurs="0"/>
                   <xs:element ref="auc:AnnualWaterCostSavings" minOccurs="0"/>
-                  <xs:element ref="auc:AnnualSavingsAverageCarbonEmissions" minOccurs="0"/>
-                  <xs:element ref="auc:AnnualSavingsMarginalCarbonEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsAverageGHGEmissions" minOccurs="0"/>
+                  <xs:element ref="auc:AnnualSavingsMarginalGHGEmissions" minOccurs="0"/>
                   <xs:element ref="auc:SimplePayback" minOccurs="0"/>
                   <xs:element ref="auc:NetPresentValue" minOccurs="0"/>
                   <xs:element ref="auc:InternalRateOfReturn" minOccurs="0"/>
@@ -3402,9 +3402,9 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
-      <xs:element minOccurs="0" name="AnnualAverageCarbonEmissions">
+      <xs:element minOccurs="0" name="AnnualAverageGHGEmissions">
         <xs:annotation>
-          <xs:documentation>Annual Average Carbon Emissions. (kg CO2e)</xs:documentation>
+          <xs:documentation>Annual Average GHG Emissions. (kg CO2e)</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:simpleContent>
@@ -3414,9 +3414,9 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="AnnualMarginalCarbonEmissions" minOccurs="0">
+      <xs:element name="AnnualMarginalGHGEmissions" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Annual Marginal Carbon Emissions. (kg CO2e)</xs:documentation>
+          <xs:documentation>Annual Marginal GHG Emissions. (kg CO2e)</xs:documentation>
         </xs:annotation>
         <xs:complexType>
           <xs:simpleContent>
@@ -15697,9 +15697,9 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="AnnualSavingsAverageCarbonEmissions">
+  <xs:element name="AnnualSavingsAverageGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Average carbon emissions savings per year. (kg CO2e/year)</xs:documentation>
+      <xs:documentation>Average GHG emissions savings per year. (kg CO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -15709,9 +15709,9 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
+  <xs:element name="AnnualSavingsMarginalGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e/year)</xs:documentation>
+      <xs:documentation>Marginal GHG emissions savings per year. (kg CO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019"
-  xmlns:gbxml="http://www.gbxml.org/schema"
-  targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified"
-  attributeFormDefault="unqualified" version="2.4.0">
-  <xs:import namespace="http://www.gbxml.org/schema"
-    schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:auc="http://buildingsync.net/schemas/bedes-auc/2019" xmlns:gbxml="http://www.gbxml.org/schema" targetNamespace="http://buildingsync.net/schemas/bedes-auc/2019" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.4.0">
+  <xs:import namespace="http://www.gbxml.org/schema" schemaLocation="https://github.com/BuildingSync/gbXML_Schemas/releases/download/v6.01/GreenBuildingXML_Ver6.01.xsd"/>
   <xs:annotation>
     <xs:documentation>BuildingSync Schema - Version 2.4.0</xs:documentation>
     <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -85,178 +80,154 @@
                           <xs:element name="HVACSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HVACSystem" type="auc:HVACSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="HVACSystem" type="auc:HVACSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LightingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LightingSystem" type="auc:LightingSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="LightingSystem" type="auc:LightingSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DomesticHotWaterSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DomesticHotWaterSystem"
-                                  type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="DomesticHotWaterSystem" type="auc:DomesticHotWaterSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CookingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CookingSystem" type="auc:CookingSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="CookingSystem" type="auc:CookingSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RefrigerationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RefrigerationSystem"
-                                  type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="RefrigerationSystem" type="auc:RefrigerationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="DishwasherSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="DishwasherSystem" type="auc:DishwasherSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="LaundrySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="LaundrySystem" type="auc:LaundrySystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PumpSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PumpSystem" type="auc:PumpSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="PumpSystem" type="auc:PumpSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FanSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FanSystem" type="auc:FanSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="FanSystem" type="auc:FanSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="MotorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="MotorSystem" type="auc:MotorSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="MotorSystem" type="auc:MotorSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="HeatRecoverySystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="HeatRecoverySystem"
-                                  type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
+                                <xs:element name="HeatRecoverySystem" type="auc:HeatRecoverySystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="WallSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WallSystem" type="auc:WallSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="WallSystem" type="auc:WallSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="RoofSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="RoofSystem" type="auc:RoofSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="RoofSystem" type="auc:RoofSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CeilingSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="CeilingSystem" type="auc:CeilingSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FenestrationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FenestrationSystem"
-                                  type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="FenestrationSystem" type="auc:FenestrationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ExteriorFloorSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ExteriorFloorSystem"
-                                  type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
+                                <xs:element name="ExteriorFloorSystem" type="auc:ExteriorFloorSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="FoundationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="FoundationSystem" type="auc:FoundationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="CriticalITSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="CriticalITSystem" type="auc:CriticalITSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="PlugLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="PlugLoad" type="auc:PlugElectricLoadType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ProcessLoads" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="ProcessLoad" type="auc:ProcessGasElectricLoadType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
                           <xs:element name="ConveyanceSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="ConveyanceSystem" type="auc:ConveyanceSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
-                          <xs:element name="OnsiteStorageTransmissionGenerationSystems"
-                            minOccurs="0">
+                          <xs:element name="OnsiteStorageTransmissionGenerationSystems" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="OnsiteStorageTransmissionGenerationSystem"
-                                  type="auc:OnsiteStorageTransmissionGenerationSystemType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="OnsiteStorageTransmissionGenerationSystem" type="auc:OnsiteStorageTransmissionGenerationSystemType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -270,8 +241,7 @@
                           <xs:element name="WaterUses" minOccurs="0">
                             <xs:complexType>
                               <xs:sequence>
-                                <xs:element name="WaterUse" type="auc:WaterUseType"
-                                  maxOccurs="unbounded"/>
+                                <xs:element name="WaterUse" type="auc:WaterUseType" maxOccurs="unbounded"/>
                               </xs:sequence>
                             </xs:complexType>
                           </xs:element>
@@ -284,14 +254,12 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="AirInfiltrationNotes" type="xs:string"
-                                        minOccurs="0">
+                                      <xs:element name="AirInfiltrationNotes" type="xs:string" minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="Tightness" type="auc:Tightness"
-                                        minOccurs="0">
+                                      <xs:element name="Tightness" type="auc:Tightness" minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Description of the infiltration characteristics for an opaque surface, fenestration unit, a thermal zone.</xs:documentation>
                                         </xs:annotation>
@@ -356,19 +324,15 @@
                                   </xs:annotation>
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element name="WaterInfiltrationNotes" type="xs:string"
-                                        minOccurs="0">
+                                      <xs:element name="WaterInfiltrationNotes" type="xs:string" minOccurs="0">
                                         <xs:annotation>
                                           <xs:documentation>Details about the the assessment. This might include methods used, criteria, evidence, or basis of evaluation.</xs:documentation>
                                         </xs:annotation>
                                       </xs:element>
-                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages"
-                                        minOccurs="0">
+                                      <xs:element name="LocationsOfExteriorWaterIntrusionDamages" minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element
-                                              name="LocationsOfExteriorWaterIntrusionDamage"
-                                              minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="LocationsOfExteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the outside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -388,13 +352,10 @@
                                           </xs:sequence>
                                         </xs:complexType>
                                       </xs:element>
-                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages"
-                                        minOccurs="0">
+                                      <xs:element name="LocationsOfInteriorWaterIntrusionDamages" minOccurs="0">
                                         <xs:complexType>
                                           <xs:sequence>
-                                            <xs:element
-                                              name="LocationsOfInteriorWaterIntrusionDamage"
-                                              minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="LocationsOfInteriorWaterIntrusionDamage" minOccurs="0" maxOccurs="unbounded">
                                               <xs:annotation>
                                                 <xs:documentation>Location of observed moisture problems on the inside of the building.</xs:documentation>
                                               </xs:annotation>
@@ -424,8 +385,7 @@
                     <xs:element name="Schedules" minOccurs="0">
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"
-                          />
+                          <xs:element name="Schedule" type="auc:ScheduleType" maxOccurs="unbounded"/>
                         </xs:sequence>
                       </xs:complexType>
                     </xs:element>
@@ -763,14 +723,12 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="OverallWindowToWallRatio" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallWindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall window to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="OverallDoorToWallRatio" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="OverallDoorToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Overall door to wall ratio of the facility. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -830,10 +788,8 @@
                         <xs:enumeration value="ENERGY STAR"/>
                         <xs:enumeration value="ENERGY STAR Certified Homes"/>
                         <xs:enumeration value="LEED"/>
-                        <xs:enumeration
-                          value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
-                        <xs:enumeration
-                          value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
+                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Performance"/>
+                        <xs:enumeration value="Home Energy Upgrade Certificate of Energy Efficiency Improvements"/>
                         <xs:enumeration value="Passive House"/>
                         <xs:enumeration value="Living Building Challenge"/>
                         <xs:enumeration value="Green Globes"/>
@@ -1126,8 +1082,7 @@
                                 <xs:element name="WallIDs">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WallID" minOccurs="0"
-                                        maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WallID" minOccurs="0" maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1137,8 +1092,7 @@
                                 <xs:element name="WindowIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:WindowID" minOccurs="0"
-                                        maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:WindowID" minOccurs="0" maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1148,8 +1102,7 @@
                                 <xs:element name="DoorIDs" minOccurs="0">
                                   <xs:complexType>
                                     <xs:sequence>
-                                      <xs:element ref="auc:DoorID" minOccurs="0"
-                                        maxOccurs="unbounded"/>
+                                      <xs:element ref="auc:DoorID" minOccurs="0" maxOccurs="unbounded"/>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>
@@ -1203,8 +1156,7 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition"
-                                      minOccurs="0">
+                                    <xs:element name="RoofCondition" type="auc:EquipmentCondition" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Description of the roof's condition.</xs:documentation>
                                       </xs:annotation>
@@ -1215,8 +1167,7 @@
                                       </xs:annotation>
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="SkylightID" minOccurs="0"
-                                            maxOccurs="unbounded">
+                                          <xs:element name="SkylightID" minOccurs="0" maxOccurs="unbounded">
                                             <xs:annotation>
                                               <xs:documentation>ID number of the skylight type associated with this side of the section.</xs:documentation>
                                             </xs:annotation>
@@ -1224,19 +1175,18 @@
                                               <xs:sequence>
                                                 <xs:element name="PercentSkylightArea" minOccurs="0">
                                                   <xs:annotation>
-                                                  <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
+                                                    <xs:documentation>The percentage of the skylight area relative to the roof area. (0-100) (%)</xs:documentation>
                                                   </xs:annotation>
                                                   <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:decimal">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
+                                                    <xs:simpleContent>
+                                                      <xs:extension base="xs:decimal">
+                                                        <xs:attribute ref="auc:Source"/>
+                                                      </xs:extension>
+                                                    </xs:simpleContent>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
-                                              <xs:attribute name="IDref" type="xs:IDREF"
-                                                use="required"/>
+                                              <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                                             </xs:complexType>
                                           </xs:element>
                                         </xs:sequence>
@@ -1471,8 +1421,7 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ThermalZone" type="auc:ThermalZoneType"
-                          maxOccurs="unbounded"/>
+                        <xs:element name="ThermalZone" type="auc:ThermalZoneType" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
@@ -2100,8 +2049,7 @@
                         <xs:element name="StandardPractice" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="StandardPracticeDescription" type="xs:string"
-                                minOccurs="0">
+                              <xs:element name="StandardPracticeDescription" type="xs:string" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the standard practice represented by this scenario (e.g., builder standard practice, portfolio average, local practice).</xs:documentation>
                                 </xs:annotation>
@@ -2113,8 +2061,7 @@
                         <xs:element name="Other" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="OtherBenchmarkDescription" type="xs:string"
-                                minOccurs="0">
+                              <xs:element name="OtherBenchmarkDescription" type="xs:string" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>General description of the benchmark scenario (e.g., original design, building next door).</xs:documentation>
                                 </xs:annotation>
@@ -2225,8 +2172,7 @@
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(d)</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh"
-                          minOccurs="0">
+                        <xs:element name="EstimatedAnnualSavings" type="auc:LowMedHigh" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>See SPC 211 Standard for Commercial Building Energy Audits section 6.1.5(e)</xs:documentation>
                           </xs:annotation>
@@ -2452,8 +2398,7 @@
       <xs:element name="AllResourceTotals" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType"
-              maxOccurs="unbounded"/>
+            <xs:element name="AllResourceTotal" type="auc:AllResourceTotalType" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -2523,22 +2468,16 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0"
-                                      maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
                                           <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                          <xs:element ref="auc:DemandRatchetPercentage"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
                                           <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
                                           <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
                                           <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
@@ -2562,69 +2501,52 @@
                               <xs:element name="RatePeriods" minOccurs="0">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="RatePeriod" minOccurs="0"
-                                      maxOccurs="unbounded">
+                                    <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
                                       <xs:complexType>
                                         <xs:sequence>
                                           <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableStartDateForDemandRate"
-                                            minOccurs="0"/>
-                                          <xs:element ref="auc:ApplicableEndDateForDemandRate"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
+                                          <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
                                           <xs:element name="TimeOfUsePeriods" minOccurs="0">
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="TimeOfUsePeriod" minOccurs="0"
-                                                  maxOccurs="unbounded">
+                                                <xs:element name="TimeOfUsePeriod" minOccurs="0" maxOccurs="unbounded">
                                                   <xs:complexType>
-                                                  <xs:sequence>
-                                                  <xs:element name="TOUNumberForRateStructure"
-                                                  type="xs:int" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The number associated with the TOU period.</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element
-                                                  name="ApplicableStartTimeForEnergyRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element name="ApplicableEndTimeForEnergyRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element
-                                                  name="ApplicableStartTimeForDemandRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element name="ApplicableEndTimeForDemandRate"
-                                                  type="xs:time" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                  <xs:element ref="auc:ElectricDemandRate"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:EnergyRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRatchetPercentage"
-                                                  minOccurs="0"/>
-                                                  </xs:sequence>
+                                                    <xs:sequence>
+                                                      <xs:element name="TOUNumberForRateStructure" type="xs:int" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The number associated with the TOU period.</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableStartTimeForEnergyRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableEndTimeForEnergyRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableStartTimeForDemandRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day from which the rate is applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element name="ApplicableEndTimeForDemandRate" type="xs:time" minOccurs="0">
+                                                        <xs:annotation>
+                                                          <xs:documentation>The time of day after which the rate is not applicable. (hh:mm:ss)</xs:documentation>
+                                                        </xs:annotation>
+                                                      </xs:element>
+                                                      <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                      <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
+                                                      <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
+                                                      <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
+                                                      <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                      <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
+                                                    </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                               </xs:sequence>
@@ -2652,80 +2574,66 @@
                                     <xs:element name="RatePeriods" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatePeriod" minOccurs="0"
-                                            maxOccurs="unbounded">
+                                          <xs:element name="RatePeriod" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                               <xs:sequence>
                                                 <xs:element ref="auc:RatePeriodName" minOccurs="0"/>
-                                                <xs:element
-                                                  ref="auc:ApplicableStartDateForEnergyRate"
-                                                  minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate"
-                                                  minOccurs="0"/>
-                                                <xs:element
-                                                  ref="auc:ApplicableStartDateForDemandRate"
-                                                  minOccurs="0"/>
-                                                <xs:element ref="auc:ApplicableEndDateForDemandRate"
-                                                  minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableStartDateForEnergyRate" minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForEnergyRate" minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableStartDateForDemandRate" minOccurs="0"/>
+                                                <xs:element ref="auc:ApplicableEndDateForDemandRate" minOccurs="0"/>
                                                 <xs:element name="RateTiers" minOccurs="0">
                                                   <xs:complexType>
-                                                  <xs:sequence>
-                                                  <xs:element name="RateTier" minOccurs="0"
-                                                  maxOccurs="unbounded">
-                                                  <xs:complexType>
-                                                  <xs:sequence>
-                                                  <xs:element
-                                                  name="ConsumptionEnergyTierDesignation"
-                                                  minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:integer">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element name="MaxkWhUsage" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:decimal">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element name="MaxkWUsage" minOccurs="0">
-                                                  <xs:annotation>
-                                                  <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
-                                                  <xs:simpleContent>
-                                                  <xs:extension base="xs:decimal">
-                                                  <xs:attribute ref="auc:Source"/>
-                                                  </xs:extension>
-                                                  </xs:simpleContent>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
-                                                  <xs:element ref="auc:ElectricDemandRate"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:EnergyRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRateAdjustment"
-                                                  minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandWindow" minOccurs="0"/>
-                                                  <xs:element ref="auc:DemandRatchetPercentage"
-                                                  minOccurs="0"/>
-                                                  </xs:sequence>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  </xs:sequence>
+                                                    <xs:sequence>
+                                                      <xs:element name="RateTier" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                          <xs:sequence>
+                                                            <xs:element name="ConsumptionEnergyTierDesignation" minOccurs="0">
+                                                            <xs:annotation>
+                                                            <xs:documentation>For electricity pricing that is based on tiered pricing, each tier is allotted a certain maximum (kWh), above which the user is moved to the next tier that has a different unit pricing.</xs:documentation>
+                                                            </xs:annotation>
+                                                            <xs:complexType>
+                                                            <xs:simpleContent>
+                                                            <xs:extension base="xs:integer">
+                                                            <xs:attribute ref="auc:Source"/>
+                                                            </xs:extension>
+                                                            </xs:simpleContent>
+                                                            </xs:complexType>
+                                                            </xs:element>
+                                                            <xs:element name="MaxkWhUsage" minOccurs="0">
+                                                            <xs:annotation>
+                                                            <xs:documentation>The maximum amount of kWh used at which a kWh rate is applied. (kWh)</xs:documentation>
+                                                            </xs:annotation>
+                                                            <xs:complexType>
+                                                            <xs:simpleContent>
+                                                            <xs:extension base="xs:decimal">
+                                                            <xs:attribute ref="auc:Source"/>
+                                                            </xs:extension>
+                                                            </xs:simpleContent>
+                                                            </xs:complexType>
+                                                            </xs:element>
+                                                            <xs:element name="MaxkWUsage" minOccurs="0">
+                                                            <xs:annotation>
+                                                            <xs:documentation>The maximum amount of kW used at which a kW rate is applied. (kW)</xs:documentation>
+                                                            </xs:annotation>
+                                                            <xs:complexType>
+                                                            <xs:simpleContent>
+                                                            <xs:extension base="xs:decimal">
+                                                            <xs:attribute ref="auc:Source"/>
+                                                            </xs:extension>
+                                                            </xs:simpleContent>
+                                                            </xs:complexType>
+                                                            </xs:element>
+                                                            <xs:element ref="auc:EnergyCostRate" minOccurs="0"/>
+                                                            <xs:element ref="auc:ElectricDemandRate" minOccurs="0"/>
+                                                            <xs:element ref="auc:EnergyRateAdjustment" minOccurs="0"/>
+                                                            <xs:element ref="auc:DemandRateAdjustment" minOccurs="0"/>
+                                                            <xs:element ref="auc:DemandWindow" minOccurs="0"/>
+                                                            <xs:element ref="auc:DemandRatchetPercentage" minOccurs="0"/>
+                                                          </xs:sequence>
+                                                        </xs:complexType>
+                                                      </xs:element>
+                                                    </xs:sequence>
                                                   </xs:complexType>
                                                 </xs:element>
                                                 <xs:element ref="auc:EnergySellRate" minOccurs="0"/>
@@ -3227,8 +3135,7 @@
                     </xs:annotation>
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element maxOccurs="unbounded" minOccurs="1"
-                          name="EmissionsLinkedTimeSeriesID">
+                        <xs:element maxOccurs="unbounded" minOccurs="1" name="EmissionsLinkedTimeSeriesID">
                           <xs:complexType>
                             <xs:attribute name="IDref" type="xs:IDREF"/>
                           </xs:complexType>
@@ -3719,8 +3626,7 @@
                   <xs:element name="Replacement" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemReplaced" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemReplaced" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems replaced by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3728,8 +3634,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element name="AlternativeSystemReplacement" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemReplacement" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would replace the existing systems.</xs:documentation>
                           </xs:annotation>
@@ -3737,8 +3642,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3752,8 +3656,7 @@
                   <xs:element name="ModificationRetrocommissioning" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="ExistingSystemAffected" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="ExistingSystemAffected" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of any existing systems affected by the measure.</xs:documentation>
                           </xs:annotation>
@@ -3769,8 +3672,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3784,8 +3686,7 @@
                   <xs:element name="Addition" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="AlternativeSystemAdded" minOccurs="0"
-                          maxOccurs="unbounded">
+                        <xs:element name="AlternativeSystemAdded" minOccurs="0" maxOccurs="unbounded">
                           <xs:annotation>
                             <xs:documentation>ID numbers of alternative systems that would be added as part of the measure.</xs:documentation>
                           </xs:annotation>
@@ -3793,8 +3694,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3816,8 +3716,7 @@
                             <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                           </xs:complexType>
                         </xs:element>
-                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0"
-                          maxOccurs="unbounded"/>
+                        <xs:element ref="auc:ExistingScheduleAffected" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element ref="auc:ModifiedSchedule" minOccurs="0" maxOccurs="unbounded"/>
                       </xs:sequence>
                     </xs:complexType>
@@ -3896,8 +3795,7 @@
                               <xs:enumeration value="Convert system from steam to hot water"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Convert to Cleaner Fuels"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -3926,8 +3824,7 @@
                               <xs:enumeration value="Add or replace cooling tower"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3951,8 +3848,7 @@
                               <xs:enumeration value="Add or upgrade BAS/EMS/EMCS"/>
                               <xs:enumeration value="Add or upgrade controls"/>
                               <xs:enumeration value="Convert pneumatic controls to DDC"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3984,8 +3880,7 @@
                               <xs:enumeration value="Replace package units"/>
                               <xs:enumeration value="Replace packaged terminal units"/>
                               <xs:enumeration value="Install passive solar heating"/>
-                              <xs:enumeration
-                                value="Replace AC and heating units with ground coupled heat pump systems"/>
+                              <xs:enumeration value="Replace AC and heating units with ground coupled heat pump systems"/>
                               <xs:enumeration value="Add enhanced dehumidification"/>
                               <xs:enumeration value="Install solar ventilation preheating system"/>
                               <xs:enumeration value="Add or repair economizer"/>
@@ -4000,8 +3895,7 @@
                               <xs:enumeration value="Install or Upgrade Master Venting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other heating"/>
                               <xs:enumeration value="Other cooling"/>
                               <xs:enumeration value="Other ventilation"/>
@@ -4029,10 +3923,8 @@
                               <xs:enumeration value="Retrofit with T-5"/>
                               <xs:enumeration value="Retrofit with T-8"/>
                               <xs:enumeration value="Install spectrally enhanced lighting"/>
-                              <xs:enumeration
-                                value="Retrofit with fiber optic lighting technologies"/>
-                              <xs:enumeration
-                                value="Retrofit with light emitting diode technologies"/>
+                              <xs:enumeration value="Retrofit with fiber optic lighting technologies"/>
+                              <xs:enumeration value="Retrofit with light emitting diode technologies"/>
                               <xs:enumeration value="Add daylight controls"/>
                               <xs:enumeration value="Add occupancy sensors"/>
                               <xs:enumeration value="Install photocell control"/>
@@ -4042,8 +3934,7 @@
                               <xs:enumeration value="Upgrade exterior lighting"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4101,10 +3992,8 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Add pipe insulation"/>
                               <xs:enumeration value="Repair and/or replace steam traps"/>
-                              <xs:enumeration
-                                value="Retrofit and replace chiller plant pumping, piping, and controls"/>
-                              <xs:enumeration
-                                value="Repair or replace existing condensate return systems or install new condensate return systems"/>
+                              <xs:enumeration value="Retrofit and replace chiller plant pumping, piping, and controls"/>
+                              <xs:enumeration value="Repair or replace existing condensate return systems or install new condensate return systems"/>
                               <xs:enumeration value="Add recirculating pumps"/>
                               <xs:enumeration value="Replace or upgrade water heater"/>
                               <xs:enumeration value="Add energy recovery"/>
@@ -4117,8 +4006,7 @@
                               <xs:enumeration value="Install steam condensate heat recovery"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4143,8 +4031,7 @@
                               <xs:enumeration value="Upgrade motors"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4169,8 +4056,7 @@
                               <xs:enumeration value="Add VSD motor controller"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4190,14 +4076,12 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration
-                                value="Replace ice/refrigeration equipment with high efficiency units"/>
+                              <xs:enumeration value="Replace ice/refrigeration equipment with high efficiency units"/>
                               <xs:enumeration value="Replace air-cooled ice/refrigeration equipment"/>
                               <xs:enumeration value="Replace refrigerators"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4223,8 +4107,7 @@
                               <xs:enumeration value="Convert fuels"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4244,17 +4127,14 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:enumeration
-                                value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
+                              <xs:enumeration value="Install landfill gas, wastewater treatment plant digester gas, or coal bed methane power plant"/>
                               <xs:enumeration value="Install photovoltaic system"/>
                               <xs:enumeration value="Install wind energy system"/>
-                              <xs:enumeration
-                                value="Install wood waste or other organic waste stream heating or power plant"/>
+                              <xs:enumeration value="Install wood waste or other organic waste stream heating or power plant"/>
                               <xs:enumeration value="Install electrical storage"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4280,8 +4160,7 @@
                               <xs:enumeration value="Install gas distribution systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4315,8 +4194,7 @@
                               <xs:enumeration value="Install tankless water heaters"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4342,8 +4220,7 @@
                               <xs:enumeration value="Implement water efficient irrigation"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4365,8 +4242,7 @@
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Install thermal energy storage"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4387,10 +4263,8 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Change to more favorable rate schedule"/>
-                              <xs:enumeration
-                                value="Energy cost reduction through rate adjustments - uncategorized"/>
-                              <xs:enumeration
-                                value="Energy service billing and meter auditing recommendations"/>
+                              <xs:enumeration value="Energy cost reduction through rate adjustments - uncategorized"/>
+                              <xs:enumeration value="Energy service billing and meter auditing recommendations"/>
                               <xs:enumeration value="Change to lower energy cost supplier(s)"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
@@ -4412,12 +4286,10 @@
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
                               <xs:enumeration value="Implement industrial process improvements"/>
-                              <xs:enumeration
-                                value="Implement production and/or manufacturing improvements"/>
+                              <xs:enumeration value="Implement production and/or manufacturing improvements"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4440,8 +4312,7 @@
                               <xs:enumeration value="Install advanced metering systems"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4469,8 +4340,7 @@
                               <xs:enumeration value="Replace washing machines"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4497,8 +4367,7 @@
                               <xs:enumeration value="Upgrade servers"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
-                              <xs:enumeration
-                                value="Upgrade operating protocols, calibration, and/or sequencing"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4978,8 +4847,7 @@
               </xs:annotation>
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType"
-                    minOccurs="0">
+                  <xs:element name="AuditorQualification" type="auc:AuditorQualificationType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Qualification of auditor responsible for the audit report.</xs:documentation>
                     </xs:annotation>
@@ -5007,8 +4875,7 @@
                       <xs:attribute name="IDref" type="xs:IDREF" use="required"/>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="AuditTeamMemberCertificationType"
-                    type="auc:AuditorQualificationType" minOccurs="0">
+                  <xs:element name="AuditTeamMemberCertificationType" type="auc:AuditorQualificationType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Type of certification held by an auditor team member.</xs:documentation>
                     </xs:annotation>
@@ -5079,8 +4946,7 @@
             <xs:element name="HeatingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0"
-                    maxOccurs="unbounded">
+                  <xs:element name="HeatingPlant" type="auc:HeatingPlantType" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of central heating system, defined as any source of heating energy separate from the zone being heated. Local heating systems (such as packaged systems and fan-coils) are recorded in a separate data field.</xs:documentation>
                     </xs:annotation>
@@ -5091,8 +4957,7 @@
             <xs:element name="CoolingPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0"
-                    maxOccurs="unbounded">
+                  <xs:element name="CoolingPlant" type="auc:CoolingPlantType" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of cooling plant. Zonal cooling is recorded in a separate data field. Use of fans or blowers by themselves without chilled air or water is not included in this definition of cooling. Stand-alone dehumidifiers are also not included.</xs:documentation>
                     </xs:annotation>
@@ -5103,8 +4968,7 @@
             <xs:element name="CondenserPlants" minOccurs="0">
               <xs:complexType>
                 <xs:sequence>
-                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0"
-                    maxOccurs="unbounded">
+                  <xs:element name="CondenserPlant" type="auc:CondenserPlantType" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                       <xs:documentation>Type of condenser used for refrigerant-based systems.</xs:documentation>
                     </xs:annotation>
@@ -5202,8 +5066,7 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature"
-                                      minOccurs="0">
+                                    <xs:element name="HeatPumpBackupHeatingSwitchoverTemperature" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Minimum outside temperature at which the heat pump can operate. (°F)</xs:documentation>
                                       </xs:annotation>
@@ -5215,8 +5078,7 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes"
-                                      minOccurs="0">
+                                    <xs:element name="HeatPumpBackupSystemFuel" type="auc:FuelTypes" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>Backup fuel used by the heat pump.</xs:documentation>
                                       </xs:annotation>
@@ -5295,16 +5157,14 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition"
-                          minOccurs="0"/>
+                        <xs:element name="HeatingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for HeatingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType"
-                                maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>Control for HeatingSource.</xs:documentation>
                                 </xs:annotation>
@@ -5357,16 +5217,13 @@
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Split DX air conditioner"/>
-                                          <xs:enumeration
-                                            value="Packaged terminal air conditioner (PTAC)"/>
+                                          <xs:enumeration value="Packaged terminal air conditioner (PTAC)"/>
                                           <xs:enumeration value="Split heat pump"/>
                                           <xs:enumeration value="Packaged terminal heat pump (PTHP)"/>
                                           <xs:enumeration value="Variable refrigerant flow"/>
-                                          <xs:enumeration
-                                            value="Packaged/unitary direct expansion/RTU"/>
+                                          <xs:enumeration value="Packaged/unitary direct expansion/RTU"/>
                                           <xs:enumeration value="Packaged/unitary heat pump"/>
-                                          <xs:enumeration
-                                            value="Single package vertical air conditioner"/>
+                                          <xs:enumeration value="Single package vertical air conditioner"/>
                                           <xs:enumeration value="Single package vertical heat pump"/>
                                           <xs:enumeration value="Other"/>
                                           <xs:enumeration value="Unknown"/>
@@ -5450,16 +5307,14 @@
                             <xs:documentation>Main fuel used by the system.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition"
-                          minOccurs="0"/>
+                        <xs:element name="CoolingSourceCondition" type="auc:EquipmentCondition" minOccurs="0"/>
                         <xs:element name="Controls" minOccurs="0">
                           <xs:annotation>
                             <xs:documentation>List of controls for CoolingSource.</xs:documentation>
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType"
-                                maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>CoolingSource control.</xs:documentation>
                                 </xs:annotation>
@@ -5514,8 +5369,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5533,8 +5387,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element ref="auc:PipeInsulationThickness"
-                                            minOccurs="0"/>
+                                          <xs:element ref="auc:PipeInsulationThickness" minOccurs="0"/>
                                           <xs:element ref="auc:PipeLocation" minOccurs="0"/>
                                         </xs:sequence>
                                       </xs:complexType>
@@ -5569,14 +5422,10 @@
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="CAV terminal box no reheat"/>
                                           <xs:enumeration value="CAV terminal box with reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box fan powered no reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box fan powered with reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box not fan powered no reheat"/>
-                                          <xs:enumeration
-                                            value="VAV terminal box not fan powered with reheat"/>
+                                          <xs:enumeration value="VAV terminal box fan powered no reheat"/>
+                                          <xs:enumeration value="VAV terminal box fan powered with reheat"/>
+                                          <xs:enumeration value="VAV terminal box not fan powered no reheat"/>
+                                          <xs:enumeration value="VAV terminal box not fan powered with reheat"/>
                                           <xs:enumeration value="Powered induction unit"/>
                                           <xs:enumeration value="Automatically controlled register"/>
                                           <xs:enumeration value="Manually controlled register"/>
@@ -5657,8 +5506,7 @@
                           </xs:annotation>
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="Control" type="auc:ControlGeneralType"
-                                maxOccurs="unbounded">
+                              <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                 <xs:annotation>
                                   <xs:documentation>DeliverySystem control.</xs:documentation>
                                 </xs:annotation>
@@ -5672,8 +5520,7 @@
                         <xs:element ref="auc:ModelNumber" minOccurs="0"/>
                         <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>
                         <xs:element ref="auc:Quantity" minOccurs="0"/>
-                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition"
-                          minOccurs="0"/>
+                        <xs:element name="DeliveryCondition" type="auc:EquipmentCondition" minOccurs="0"/>
                       </xs:sequence>
                       <xs:attribute name="ID" type="xs:ID" use="required"/>
                       <xs:attribute ref="auc:Status">
@@ -5699,8 +5546,7 @@
       <xs:element name="OtherHVACSystems" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"
-            />
+            <xs:element name="OtherHVACSystem" type="auc:OtherHVACSystemType" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -5986,8 +5832,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="SupplyFractionOfDuctLeakage" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of total duct leakage that is on the supply side. Remainder is assumed to be on the return side. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -6392,8 +6237,7 @@
               <xs:element ref="auc:CapacityUnits" minOccurs="0"/>
               <xs:element ref="auc:MinimumPartLoadRatio" minOccurs="0"/>
               <xs:element ref="auc:RatedCoolingSensibleHeatRatio" minOccurs="0"/>
-              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0"
-                type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+              <xs:element name="PartLoadRatioBelowWhichHotGasBypassOperates" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                 <xs:annotation>
                   <xs:documentation>The part load ratio of the chiller below which hot gas bypass (HGBP) operates. (0-1) (fraction)</xs:documentation>
                 </xs:annotation>
@@ -7292,14 +7136,12 @@
         </xs:annotation>
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="MinimumDimmingLightFraction" minOccurs="0"
-              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingLightFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>Minimum light output of controlled lighting when fully dimmed. Minimum light fraction = (Minimum light output) / (Rated light output). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0"
-              type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+            <xs:element name="MinimumDimmingPowerFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
               <xs:annotation>
                 <xs:documentation>The minimum power fraction when controlled lighting is fully dimmed. Minimum power fraction = (Minimum power) / (Full rated power). (0-1) (fraction)</xs:documentation>
               </xs:annotation>
@@ -7544,9 +7386,7 @@
                                     <xs:element name="HeatPump" minOccurs="0">
                                       <xs:complexType>
                                         <xs:sequence>
-                                          <xs:element name="RatedHeatPumpSensibleHeatRatio"
-                                            minOccurs="0"
-                                            type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                                          <xs:element name="RatedHeatPumpSensibleHeatRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                                             <xs:annotation>
                                               <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
                                             </xs:annotation>
@@ -7585,8 +7425,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorArea"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorArea" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Area of solar collector exposed to solar radiation. (ft2)</xs:documentation>
                                             </xs:annotation>
@@ -7598,8 +7437,7 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorLoopType"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorLoopType" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Heat transfer medium and controls used for the solar collector loop.</xs:documentation>
                                             </xs:annotation>
@@ -7615,8 +7453,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorType"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorType" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Type of solar energy collector used in a solar hot water or space heating system.</xs:documentation>
                                             </xs:annotation>
@@ -7633,8 +7470,7 @@
                                               </xs:restriction>
                                             </xs:simpleType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorAzimuth"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorAzimuth" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Degrees clockwise from North. For a premises, it is the azimuth of the front facing element. It can also be applied to envelope components, such as walls, windows (fenestration), as well as onsite generation technologies, such as photovoltaic panels. (0 - 360) (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7646,8 +7482,7 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemCollectorTilt"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemCollectorTilt" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>The angle from a horizontal surface; can be applied to an opaque surface, a fenestration unit, a solar panel, etc. (degrees)</xs:documentation>
                                             </xs:annotation>
@@ -7659,8 +7494,7 @@
                                               </xs:simpleContent>
                                             </xs:complexType>
                                           </xs:element>
-                                          <xs:element name="SolarThermalSystemStorageVolume"
-                                            minOccurs="0">
+                                          <xs:element name="SolarThermalSystemStorageVolume" minOccurs="0">
                                             <xs:annotation>
                                               <xs:documentation>Volume of any separate solar energy storage tank, not the primary service hot water tank. (gal)</xs:documentation>
                                             </xs:annotation>
@@ -7678,11 +7512,9 @@
                                             </xs:annotation>
                                             <xs:complexType>
                                               <xs:sequence>
-                                                <xs:element name="Control"
-                                                  type="auc:ControlGeneralType"
-                                                  maxOccurs="unbounded">
+                                                <xs:element name="Control" type="auc:ControlGeneralType" maxOccurs="unbounded">
                                                   <xs:annotation>
-                                                  <xs:documentation>Solar hot water control.</xs:documentation>
+                                                    <xs:documentation>Solar hot water control.</xs:documentation>
                                                   </xs:annotation>
                                                 </xs:element>
                                               </xs:sequence>
@@ -8864,8 +8696,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="FanPowerMinimumRatio" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="FanPowerMinimumRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>The minimum power draw of the fan, expressed as a ratio of the full load fan power. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -9285,8 +9116,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType"
-                    minOccurs="0">
+                  <xs:element name="WallInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9317,8 +9147,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition"
-                    minOccurs="0"/>
+                  <xs:element name="WallInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                   <xs:element name="WallInsulationLocation" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Whether wall insulation is on the inside or outside of the wall.</xs:documentation>
@@ -9503,8 +9332,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType"
-                    minOccurs="0">
+                  <xs:element name="CeilingInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9535,8 +9363,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition"
-                    minOccurs="0"/>
+                  <xs:element name="CeilingInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
@@ -9683,8 +9510,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType"
-                    minOccurs="0">
+                  <xs:element name="RoofInsulationMaterial" type="auc:InsulationMaterialType" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Material used for the structural component of the surface.</xs:documentation>
                     </xs:annotation>
@@ -9715,8 +9541,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition"
-                    minOccurs="0"/>
+                  <xs:element name="RoofInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                   <xs:element name="RoofInsulationRValue" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Insulation R Value of the layer. (hr-ft2-F/Btu)</xs:documentation>
@@ -10213,8 +10038,7 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0"
-                    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+                  <xs:element name="DoorGlazedAreaFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
                     <xs:annotation>
                       <xs:documentation>Fraction of door area that is glazed. (0-1) (fraction)</xs:documentation>
                     </xs:annotation>
@@ -10553,8 +10377,7 @@
                                         </xs:simpleContent>
                                       </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="FloorInsulationCondition"
-                                      type="auc:InsulationCondition" minOccurs="0"/>
+                                    <xs:element name="FloorInsulationCondition" type="auc:InsulationCondition" minOccurs="0"/>
                                     <xs:element name="FloorRValue" minOccurs="0">
                                       <xs:annotation>
                                         <xs:documentation>(Also known as thermal resistance), quantity determined by the temperature difference, at steady state, between two defined surfaces of a material or construction that induces a unit heat flow rate through unit area (R = ΔT/q). R-value is the reciprocal of thermal conductance. A unit of thermal resistance used for comparing insulating values of different materials, for the specific thickness of the material. The higher the R-value number, a material, the greater its insulating properties and the slower the heat flow through it. This R-value does not include the interior and exterior air film coefficients. (hr-ft2-F/Btu)</xs:documentation>
@@ -10623,14 +10446,11 @@
                                   <xs:sequence>
                                     <xs:element ref="auc:FoundationWallConstruction" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationHeightAboveGrade" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationThickness"
-                                      minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationThickness" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallRValue" minOccurs="0"/>
                                     <xs:element ref="auc:FoundationWallUFactor" minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationContinuity"
-                                      minOccurs="0"/>
-                                    <xs:element ref="auc:FoundationWallInsulationCondition"
-                                      minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationContinuity" minOccurs="0"/>
+                                    <xs:element ref="auc:FoundationWallInsulationCondition" minOccurs="0"/>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -10947,8 +10767,7 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:WeightedAverageLoad" minOccurs="0"/>
-      <xs:element name="HeatGainFraction" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="HeatGainFraction" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Fraction of installed power that results in heat gain to the space. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -11142,8 +10961,7 @@
                         <xs:element name="PV" minOccurs="0">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray"
-                                minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemNumberOfModulesPerArray" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Number of modules in each array of a photovoltaic system.</xs:documentation>
                                 </xs:annotation>
@@ -11203,8 +11021,7 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin"
-                                minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMin" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Minimum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -11216,8 +11033,7 @@
                                   </xs:simpleContent>
                                 </xs:complexType>
                               </xs:element>
-                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax"
-                                minOccurs="0">
+                              <xs:element name="PhotovoltaicSystemRackingSystemTiltAngleMax" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Maximum PV mounting angle relative to horizontal. Minimum and maximum tilt angles are the same for fixed systems. (degrees)</xs:documentation>
                                 </xs:annotation>
@@ -11308,8 +11124,7 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="OutputResourceType" type="auc:FuelTypes"
-                                minOccurs="0">
+                              <xs:element name="OutputResourceType" type="auc:FuelTypes" minOccurs="0">
                                 <xs:annotation>
                                   <xs:documentation>Resource or fuel produced by the generation system and used as energy on the premises.</xs:documentation>
                                 </xs:annotation>
@@ -11580,8 +11395,7 @@
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0"
-        type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+      <xs:element name="WaterFixtureFractionHotWater" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
         <xs:annotation>
           <xs:documentation>Average fraction of water use for this application that is drawn from the hot water system. (0-1) (fraction)</xs:documentation>
         </xs:annotation>
@@ -13855,59 +13669,37 @@
       <xs:enumeration value="Professional Engineer (PE)"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Certified Member Agency"/>
       <xs:enumeration value="Associated Air Balance Council (AABC) Test and Balance Technician"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Carbon Reduction Manager (CRM)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Sustainable Development Professional (CSDP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Power Quality Professional (CPQ)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Demand Side Manager (CDSM)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Energy Procurement Professional (CEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Lighting Efficiency Professional (CLEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Measurement &amp; Verification Professional (CMVP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified GeoExchange Designer Program (CGD)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Business Energy Professional (BEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Industrial Energy Professional (CIEP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Water Efficiency Professional (CWEP)"/>
       <xs:enumeration value="Association of Energy Engineers Energy Efficiency Practitioner (EEP)"/>
       <xs:enumeration value="Association of Energy Engineers Renewable Energy Professional (REP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
+      <xs:enumeration value="Association of Energy Engineers Distributed Generation Certified Professional (DGCP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Building Energy Simulation Analyst (BESA)"/>
+      <xs:enumeration value="Association of Energy Engineers Performance Contracting and Funding Professional (PCF)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Residential Energy Auditor (REA)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Firm Program (CBCF)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Green Building Engineer (GBE)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Manager (CEM)"/>
       <xs:enumeration value="Association of Energy Engineers Certified Energy Auditor (CEA)"/>
-      <xs:enumeration
-        value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
+      <xs:enumeration value="Association of Energy Engineers Certified Building Commissioning Professional (CBCP)"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 1"/>
       <xs:enumeration value="Building Operator Certification (BOC): Level 2"/>
       <xs:enumeration value="Building Performance Institute (BPI) Certification"/>
       <xs:enumeration value="Building Performance Institute (BPI): Building Analyst (BA)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
-      <xs:enumeration
-        value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional (HEP)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Energy Auditor (HEP-EA)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Quality Control Inspector (HEP-QCI)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Retrofit Installer (HEP-RI)"/>
+      <xs:enumeration value="Building Performance Institute (BPI): Advanced Home Energy Professional - Crew Leader (HEP-CL)"/>
       <xs:enumeration value="Building Performance Institute (BPI): Multifamily Building Analyst"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) Certification"/>
       <xs:enumeration value="Residential Energy Services Network (RESNET) - Home Partner"/>
@@ -14117,8 +13909,7 @@
   </xs:complexType>
   <xs:complexType name="FanBasedType">
     <xs:sequence>
-      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType"
-        minOccurs="0"/>
+      <xs:element name="FanBasedDistributionType" type="auc:FanBasedDistributionTypeType" minOccurs="0"/>
       <xs:element name="AirSideEconomizer" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
@@ -14510,8 +14301,7 @@
                 </xs:simpleContent>
               </xs:complexType>
             </xs:element>
-            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType"
-              minOccurs="0">
+            <xs:element name="ControlStrategy" type="auc:ControlStrategyDaylightingType" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Daylighting control strategy.</xs:documentation>
               </xs:annotation>
@@ -14594,8 +14384,7 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType"
-                minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolAnalogType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over an analog network.</xs:documentation>
                 </xs:annotation>
@@ -14609,8 +14398,7 @@
           </xs:annotation>
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType"
-                minOccurs="0">
+              <xs:element name="CommunicationProtocol" type="auc:CommunicationProtocolDigitalType" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>Method of communicating data over a digital computer network.</xs:documentation>
                 </xs:annotation>
@@ -15205,8 +14993,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="auc:FenestrationArea" minOccurs="0"/>
-        <xs:element name="WindowToWallRatio" minOccurs="0"
-          type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+        <xs:element name="WindowToWallRatio" minOccurs="0" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
           <xs:annotation>
             <xs:documentation>Ratio of total window area to total wall area. (0-1) (fraction)</xs:documentation>
           </xs:annotation>
@@ -15253,32 +15040,26 @@
                         <xs:element name="ResponseVariable" minOccurs="1" maxOccurs="1">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ResponseVariableName" type="auc:FuelTypes"
-                                minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType"
-                                minOccurs="1" maxOccurs="1"/>
-                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType"
-                                minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableName" type="auc:FuelTypes" minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableUnits" type="auc:ResourceUnitsType" minOccurs="1" maxOccurs="1"/>
+                              <xs:element name="ResponseVariableEndUse" type="auc:EndUseType" minOccurs="1" maxOccurs="1"/>
                             </xs:sequence>
                           </xs:complexType>
                         </xs:element>
                         <xs:element name="ExplanatoryVariables">
                           <xs:complexType>
                             <xs:sequence>
-                              <xs:element name="ExplanatoryVariable" minOccurs="1"
-                                maxOccurs="unbounded">
+                              <xs:element name="ExplanatoryVariable" minOccurs="1" maxOccurs="unbounded">
                                 <xs:complexType>
                                   <xs:sequence>
-                                    <xs:element name="ExplanatoryVariableName" minOccurs="1"
-                                      maxOccurs="1">
+                                    <xs:element name="ExplanatoryVariableName" minOccurs="1" maxOccurs="1">
                                       <xs:simpleType>
                                         <xs:restriction base="xs:string">
                                           <xs:enumeration value="Drybulb Temperature"/>
                                           <xs:enumeration value="Wetbulb Temperature"/>
                                           <xs:enumeration value="Relative Humidity"/>
                                           <xs:enumeration value="Global Horizontal Irradiance (GHI)"/>
-                                          <xs:enumeration
-                                            value="Diffuse Horizontal Irradiance (DHI)"/>
+                                          <xs:enumeration value="Diffuse Horizontal Irradiance (DHI)"/>
                                           <xs:enumeration value="Direct Normal Irradiance (DNI)"/>
                                           <xs:enumeration value="Hour of week">
                                             <xs:annotation>
@@ -15344,8 +15125,7 @@
                                         </xs:restriction>
                                       </xs:simpleType>
                                     </xs:element>
-                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"
-                                      > </xs:element>
+                                    <xs:element name="ExplanatoryVariableUnits" type="auc:UnitsType"> </xs:element>
                                   </xs:sequence>
                                 </xs:complexType>
                               </xs:element>
@@ -15375,8 +15155,7 @@
                                   </xs:restriction>
                                 </xs:simpleType>
                               </xs:element>
-                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0"
-                                maxOccurs="1">
+                              <xs:element name="Intercept" type="xs:decimal" minOccurs="0" maxOccurs="1">
                                 <xs:annotation>
                                   <xs:documentation>The 'y-intercept' value.  In Figure D-1 (a), this is Eb.  In Figure D-1 (a)-(g), this is C.</xs:documentation>
                                 </xs:annotation>
@@ -15492,32 +15271,27 @@
                   <xs:element name="SummaryInformation" minOccurs="0">
                     <xs:complexType>
                       <xs:sequence>
-                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="NumberOfDataPoints" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of periods in the Baseline period data.  It is denoted as "n" throughout B4.  A "period" refers to a measurement of the ResponseVariable.  For example, 24 hours worth of data collected at hourly intervals would have 24 "periods".</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="NumberOfParameters" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>As documented in Annex B4 of ASRHAE Guideline 14-2018, this refers to the total number of parameters in the model.  It is denoted as "p" throughout B4.  The number of parameters is not necessarily equal to the number of auc:ExplanatoryVariable elements.  For example, a 5 parameter change point model has 5 parameters, even though there is only a single ExplanatoryVariable (likely Drybulb Temperature).  In certain cases, this is used in the calculation of the degrees of freedom for the t-statistic.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="DegreesOfFreedom" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>Degrees of Freedom as used in the context of a t-distribution.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="AggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the actual energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits. See: the Retrofit Isolation Approach (G-14 4.1.1) and Whole Facility Approach (G-14 4.1.2) of ASHRAE Guideline 14-2018.</xs:documentation>
                           </xs:annotation>
                         </xs:element>
-                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0"
-                          maxOccurs="1">
+                        <xs:element name="AggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                           <xs:annotation>
                             <xs:documentation>This value represents the model estimated energy use for the building / premise over the defined period. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                           </xs:annotation>
@@ -15576,26 +15350,22 @@
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1"
-                    maxOccurs="1">
+                  <xs:element name="ComparisonPeriodStartTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The beginning of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1"
-                    maxOccurs="1">
+                  <xs:element name="ComparisonPeriodEndTimestamp" type="xs:dateTime" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable regardless of the NormalizationMethod. The end of the time period used for comparison.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateActualEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the actual energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="ComparisonPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. This value represents the model estimated energy use for the building / premise during the period of comparison. It is an aggregate number and should be of the same units defined by the ResponseVariable/ResponseVariableUnits.</xs:documentation>
                     </xs:annotation>
@@ -15605,38 +15375,32 @@
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. As documented in Annex B4.1g and the result of Equation B-14 of ASHRAE Guideline 14-2018 (E_save,m), this value represents the 'actual savings'.  It is calculated via the following: E_save,m = Ehat_base,m - E_meas,m.  In BuildingSync terms, the AvoidedEnergyUse = ComparisonPeriodAggregateModeledEnergyUse - ComparisonPeriodAggregateActualEnergyUse.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0"
-                    maxOccurs="1">
+                  <xs:element name="SavingsUncertainty" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The savings uncertainty represented as a decimal.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="ConfidenceLevel" type="auc:BoundedDecimalZeroToOne" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>The confidence level represented as a decimal between zero and one.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse"
-                    type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized baseline energy use", or the predicted energy consumption using the Baseline model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse"
-                    type="xs:decimal" minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodAggregateModeledEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions.  As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "In many cases, it is necessary to normalize the savings to a typical or average period (usually a year) at the site. It was shown in Section B4.3 that when measurement errors are negligible, the uncertainty in calculating actual savings using a weather-based regression is due to the error in normalizing the baseline energy use to the postretrofit period. Normalized savings requires two regression equations: one that correlates baseline energy use with baseline weather conditions and one that correlates postretrofit energy use with postretrofit weather conditions.  This value represents the "normalized postretrofit energy use", or the predicted energy consumption using the Reporting (or postretrofit) model when data from a standard year (or typical year) is supplied to it.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsAvoidedEnergyUse" type="xs:decimal" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. As documented in Annex B4.5 of ASRHAE Guideline 14-2018: "normalized savings is then defined as the normalized baseline energy use minus the normalized postretrofit energy use".  The "normalized baseline energy use" referred to in G-14 is captured by the auc:BaselinePeriodCalculatedEnergyUseStandardConditions element, while the "normalized postretrofit energy use" is captured by the auc:ReportingPeriodCalculatedEnergyUseStandardConditions element.</xs:documentation>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0"
-                    maxOccurs="1">
+                  <xs:element name="ComparisonPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Forecast or Backcast. Used to capture the modeled timeseries data associated with the comparison period.</xs:documentation>
                     </xs:annotation>
@@ -15646,8 +15410,7 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsBaselinePeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the baseline period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15657,8 +15420,7 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
-                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData"
-                    minOccurs="0" maxOccurs="1">
+                  <xs:element name="StandardConditionsReportingPeriodModeledTimeSeriesData" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                       <xs:documentation>Applicable when the NormalizationMethod is Standard Conditions. Used to capture the modeled timeseries data associated with the reporting period at standard conditions.</xs:documentation>
                     </xs:annotation>
@@ -15712,9 +15474,7 @@
     <xs:annotation>
       <xs:documentation>Enumeration for different potential units.</xs:documentation>
     </xs:annotation>
-    <xs:union
-      memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"
-    />
+    <xs:union memberTypes="auc:ResourceUnitsType auc:PressureUnitsType auc:PeakResourceUnitsType auc:TemperatureUnitsType"/>
   </xs:simpleType>
   <xs:simpleType name="DimensionlessUnitsType">
     <xs:union memberTypes="auc:OtherUnitsType auc:DimensionlessUnitsBaseType"/>
@@ -16423,8 +16183,7 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
-  <xs:element name="HeatingStageCapacityFraction"
-    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="HeatingStageCapacityFraction" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>Average capacity of each heating stage, at Air-Conditioning, Heating, and Refrigeration Institute (AHRI) rated conditions, expressed as a fraction of total capacity. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -16768,8 +16527,7 @@
       <xs:documentation>The name or title of rate period.  This is intended to capture the seasonal changes in rates.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  <xs:element name="RatedCoolingSensibleHeatRatio"
-    type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
+  <xs:element name="RatedCoolingSensibleHeatRatio" type="auc:BoundedDecimalZeroToOneWithSourceAttribute">
     <xs:annotation>
       <xs:documentation>The fraction of total energy transfer between the evaporator coil and air that is associated with sensible capacity (change in air temperature) expressed as a dimensionless value, and at the rated conditions prescribed for this system. (0-1) (fraction)</xs:documentation>
     </xs:annotation>
@@ -17062,8 +16820,7 @@
   <xs:element name="SpatialUnits">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1"
-          maxOccurs="unbounded"/>
+        <xs:element name="SpatialUnit" type="auc:SpatialUnitTypeType" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/docs/notebooks/example1-with-sensors.xml
+++ b/docs/notebooks/example1-with-sensors.xml
@@ -1,0 +1,1032 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<BuildingSync xmlns="http://buildingsync.net/schemas/bedes-auc/2019"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://buildingsync.net/schemas/bedes-auc/2019 ../../BuildingSync.xsd"
+  version="2.4.0">
+  <Facilities>
+    <Facility ID="Facility-1">
+      <Sites>
+        <Site ID="Site-1">
+          <Buildings>
+            <Building ID="Building-Small-Office-Prototype">
+              <PremisesName>Small Office Prototype</PremisesName>
+              <PremisesNotes>Here we record general problems / issues identified in a walkthrough survey.</PremisesNotes>
+              <Address>
+                <StreetAddressDetail>
+                  <Simplified>
+                    <StreetAddress>4055 Brooks Street</StreetAddress>
+                  </Simplified>
+                </StreetAddressDetail>
+                <City>Missoula</City>
+                <State>MT</State>
+                <PostalCode>59804</PostalCode>
+              </Address>
+              <BuildingClassification>Commercial</BuildingClassification>
+              <OccupancyClassification>Office</OccupancyClassification>
+              <PrimaryContactID IDref="Contact-Owner"/>
+              <FloorsAboveGrade>1</FloorsAboveGrade>
+              <FloorsBelowGrade>0</FloorsBelowGrade>
+              <ConditionedFloorsAboveGrade>1</ConditionedFloorsAboveGrade>
+              <ConditionedFloorsBelowGrade>0</ConditionedFloorsBelowGrade>
+              <HistoricalLandmark>false</HistoricalLandmark>
+              <FloorAreas>
+                <FloorArea>
+                  <FloorAreaType>Gross</FloorAreaType>
+                  <FloorAreaValue>5500.000000</FloorAreaValue>
+                </FloorArea>
+                <FloorArea>
+                  <FloorAreaType>Conditioned</FloorAreaType>
+                  <FloorAreaValue>5500.000000</FloorAreaValue>
+                </FloorArea>
+              </FloorAreas>
+              <YearOfConstruction>2006</YearOfConstruction>
+              <YearOccupied>2006</YearOccupied>
+              <YearOfLastMajorRemodel>2006</YearOfLastMajorRemodel>
+              <Sections>
+                <Section ID="Section-1">
+                  <SectionType>Space function</SectionType>
+                  <OccupancyClassification>Office</OccupancyClassification>
+                  <OriginalOccupancyClassification>Office</OriginalOccupancyClassification>
+                  <OccupancyLevels>
+                    <OccupancyLevel>
+                      <OccupantQuantityType>Peak total occupants</OccupantQuantityType>
+                      <OccupantQuantity>31.000000</OccupantQuantity>
+                    </OccupancyLevel>
+                  </OccupancyLevels>
+                  <TypicalOccupantUsages>
+                    <TypicalOccupantUsage>
+                      <TypicalOccupantUsageValue>40.000000</TypicalOccupantUsageValue>
+                      <TypicalOccupantUsageUnits>Hours per week</TypicalOccupantUsageUnits>
+                    </TypicalOccupantUsage>
+                    <TypicalOccupantUsage>
+                      <TypicalOccupantUsageValue>50.000000</TypicalOccupantUsageValue>
+                      <TypicalOccupantUsageUnits>Weeks per year</TypicalOccupantUsageUnits>
+                    </TypicalOccupantUsage>
+                  </TypicalOccupantUsages>
+                  <FloorAreas>
+                    <FloorArea>
+                      <FloorAreaType>Gross</FloorAreaType>
+                      <FloorAreaValue>5500.000000</FloorAreaValue>
+                    </FloorArea>
+                    <FloorArea>
+                      <FloorAreaType>Conditioned</FloorAreaType>
+                      <FloorAreaValue>5500.000000</FloorAreaValue>
+                    </FloorArea>
+                  </FloorAreas>
+                </Section>
+              </Sections>
+            </Building>
+          </Buildings>
+        </Site>
+      </Sites>
+      <Systems>
+        <HVACSystems>
+          <HVACSystem ID="HVACSystem-1">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-2">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-3">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-4">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+          <HVACSystem ID="HVACSystem-5">
+            <PrincipalHVACSystemType>Packaged Rooftop Heat Pump</PrincipalHVACSystemType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </HVACSystem>
+        </HVACSystems>
+        <LightingSystems>
+          <LightingSystem ID="LightingSystem-1">
+            <LampType>
+              <LinearFluorescent>
+                <LampLabel>T8</LampLabel>
+              </LinearFluorescent>
+            </LampType>
+            <BallastType>Standard Electronic</BallastType>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </LightingSystem>
+        </LightingSystems>
+        <PlugLoads>
+          <PlugLoad ID="PlugLoad-1">
+            <WeightedAverageLoad>0.630000</WeightedAverageLoad>
+            <LinkedPremises>
+              <Section>
+                <LinkedSectionID IDref="Section-1"/>
+              </Section>
+            </LinkedPremises>
+          </PlugLoad>
+        </PlugLoads>
+      </Systems>
+      <Measures>
+        <Measure ID="Measure-LEDs">
+          <TypeOfMeasure>
+            <Replacements>
+              <Replacement>
+                <ExistingSystemReplaced IDref="LightingSystem-1"/>
+              </Replacement>
+            </Replacements>
+          </TypeOfMeasure>
+          <SystemCategoryAffected>Lighting</SystemCategoryAffected>
+          <TechnologyCategories>
+            <TechnologyCategory>
+              <LightingImprovements>
+                <MeasureName>Retrofit with light emitting diode technologies</MeasureName>
+              </LightingImprovements>
+            </TechnologyCategory>
+          </TechnologyCategories>
+          <LongDescription>This measure is designed to replace all fluorescent bulbs with LEDs</LongDescription>
+        </Measure>
+        <Measure ID="Measure-VSDs">
+          <TypeOfMeasure>
+            <ModificationRetrocommissions>
+              <ModificationRetrocommissioning>
+                <ExistingSystemAffected IDref="HVACSystem-1"/>
+                <ExistingSystemAffected IDref="HVACSystem-2"/>
+                <ExistingSystemAffected IDref="HVACSystem-3"/>
+                <ExistingSystemAffected IDref="HVACSystem-4"/>
+                <ExistingSystemAffected IDref="HVACSystem-5"/>
+              </ModificationRetrocommissioning>
+            </ModificationRetrocommissions>
+          </TypeOfMeasure>
+          <SystemCategoryAffected>Fan</SystemCategoryAffected>
+          <TechnologyCategories>
+            <TechnologyCategory>
+              <OtherElectricMotorsAndDrives>
+                <MeasureName>Add VSD motor controller</MeasureName>
+              </OtherElectricMotorsAndDrives>
+            </TechnologyCategory>
+          </TechnologyCategories>
+          <LongDescription>This measure is designed to retrofit all RTU fans with a VSD</LongDescription>
+        </Measure>
+      </Measures>
+      <Reports>
+        <Report ID="Report-L1-Audit">
+          <Scenarios>
+            <Scenario ID="Scenario-1">
+              <ScenarioType>
+                <CurrentBuilding>
+                  <CalculationMethod>
+                    <Measured/>
+                  </CalculationMethod>
+                </CurrentBuilding>
+              </ScenarioType>
+              <ResourceUses>
+                <ResourceUse ID="ResourceUse-Electricity">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUseNotes>This is required for L1 to document irregularities in monthly energy patterns (Std 211 6.1.2.1.j). No irregularities found.</ResourceUseNotes>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>68516.730000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>234.000000</AnnualFuelUseConsistentUnits>
+                  <AnnualFuelUseLinkedTimeSeriesIDs>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-1"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-2"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-3"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-4"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-5"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-6"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-7"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-8"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-9"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-10"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-11"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-12"/>
+                  </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <PeakResourceUnits>kW</PeakResourceUnits>
+                  <AnnualPeakNativeUnits>21.120000</AnnualPeakNativeUnits>
+                  <AnnualPeakConsistentUnits>21.120000</AnnualPeakConsistentUnits>
+                  <AnnualFuelCost>5304.000000</AnnualFuelCost>
+                  <UtilityIDs>
+                    <UtilityID IDref="Utility-Electric"/>
+                  </UtilityIDs>
+                </ResourceUse>
+                <ResourceUse ID="ResourceUse-Natural-gas">
+                  <EnergyResource>Natural gas</EnergyResource>
+                  <ResourceUseNotes>No irregularities in monthly energy consumption found.</ResourceUseNotes>
+                  <ResourceUnits>MMBtu</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>17.160000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>17.160000</AnnualFuelUseConsistentUnits>
+                  <AnnualFuelUseLinkedTimeSeriesIDs>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-1"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-2"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-3"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-4"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-5"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-6"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-7"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-8"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-9"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-10"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-11"/>
+                    <LinkedTimeSeriesID IDref="TS-ResourceUse-Natural-gas-Energy-12"/>
+                  </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <AnnualFuelCost>91.630000</AnnualFuelCost>
+                  <UtilityIDs>
+                    <UtilityID IDref="Utility-Natural-Gas"/>
+                  </UtilityIDs>
+                </ResourceUse>
+              </ResourceUses>
+              <TimeSeriesData>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6792.890000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5841.750000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6025.190000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>4985.300000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5184.040000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5358.550000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5755.670000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5981.780000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5401.940000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5225.840000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5672.150000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Energy-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6291.630000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5.700000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>4.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.580000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.400000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.020000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.360000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Energy-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6.080000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-1">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>15.420000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-2">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>15.500000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-3">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>16.250000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-4">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>16.650000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-5">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>18.560000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-6">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.010000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-7">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.820000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-8">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.120000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-9">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.420000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-10">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>20.080000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-11">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>17.400000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Power-12">
+                  <ReadingType>Peak</ReadingType>
+                  <TimeSeriesReadingQuantity>Power</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>16.300000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-1">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>520.480000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-2">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>451.530000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-3">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>464.830000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-4">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>389.430000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-5">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>403.840000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-6">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>416.490000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-7">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>445.290000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-8">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>461.680000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-9">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>419.640000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-10">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>406.870000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-11">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>439.230000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Electricity-Cost-12">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>484.140000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-1">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>30.440000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-2">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>21.410000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-3">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>3.100000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-4">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>2.140000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-5">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.110000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-6">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-7">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-8">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-9">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.000000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-10">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>0.050000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-11">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>1.920000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-Natural-gas-Cost-12">
+                  <ReadingType>Cost</ReadingType>
+                  <TimeSeriesReadingQuantity>Cost</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>32.470000</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Natural-gas"/>
+                </TimeSeries>
+              </TimeSeriesData>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-1">
+                  <SiteEnergyUse>250953.500000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>45.600000</SiteEnergyUseIntensity>
+                  <SourceEnergyUse>759011.900000</SourceEnergyUse>
+                  <SourceEnergyUseIntensity>138.000000</SourceEnergyUseIntensity>
+                  <BuildingEnergyUse>250953.500000</BuildingEnergyUse>
+                  <BuildingEnergyUseIntensity>45.600000</BuildingEnergyUseIntensity>
+                  <ImportedEnergyConsistentUnits>250.953500</ImportedEnergyConsistentUnits>
+                  <OnsiteEnergyProductionConsistentUnits>0.000000</OnsiteEnergyProductionConsistentUnits>
+                  <ExportedEnergyConsistentUnits>0.000000</ExportedEnergyConsistentUnits>
+                  <NetIncreaseInStoredEnergyConsistentUnits>0.000000</NetIncreaseInStoredEnergyConsistentUnits>
+                  <EnergyCost>5395.000000</EnergyCost>
+                  <EnergyCostIndex>0.980000</EnergyCostIndex>
+                </AllResourceTotal>
+              </AllResourceTotals>
+            </Scenario>
+            <Scenario ID="Scenario-Benchmark">
+              <ScenarioType>
+                <Benchmark>
+                  <BenchmarkType>
+                    <PortfolioManager>
+                      <PMBenchmarkDate>2021-03-24</PMBenchmarkDate>
+                    </PortfolioManager>
+                  </BenchmarkType>
+                  <BenchmarkTool>Portfolio Manager</BenchmarkTool>
+                  <BenchmarkYear>2019</BenchmarkYear>
+                  <BenchmarkValue>56.000000</BenchmarkValue>
+                </Benchmark>
+              </ScenarioType>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-Benchmark">
+                  <SiteEnergyUse>274825.000000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>50.000000</SiteEnergyUseIntensity>
+                </AllResourceTotal>
+              </AllResourceTotals>
+            </Scenario>
+            <Scenario ID="Scenario-Target">
+              <ScenarioType>
+                <Target>
+                  <ReferenceCase IDref="Scenario-Benchmark"/>
+                  <AnnualSavingsSiteEnergy>67181.500000</AnnualSavingsSiteEnergy>
+                  <AnnualSavingsCost>931</AnnualSavingsCost>
+                  <ENERGYSTARScore>70.000000</ENERGYSTARScore>
+                </Target>
+              </ScenarioType>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-Target">
+                  <SiteEnergyUse>207643.500000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>37.800000</SiteEnergyUseIntensity>
+                  <EnergyCost>4451.510000</EnergyCost>
+                  <EnergyCostIndex>0.810000</EnergyCostIndex>
+                </AllResourceTotal>
+              </AllResourceTotals>
+            </Scenario>
+            <Scenario ID="Scenario-POM-LEDs">
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-LEDs">
+                  <ReferenceCase IDref="Scenario-1"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-LEDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <SimpleImpactAnalysis>
+                    <ImpactOnOccupantComfort>Low</ImpactOnOccupantComfort>
+                    <EstimatedCost>Medium</EstimatedCost>
+                    <EstimatedAnnualSavings>Medium</EstimatedAnnualSavings>
+                    <EstimatedROI>High</EstimatedROI>
+                    <Priority>Medium</Priority>
+                  </SimpleImpactAnalysis>
+                </PackageOfMeasures>
+              </ScenarioType>
+            </Scenario>
+            <Scenario ID="Scenario-POM-VSDs">
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-VSDs">
+                  <ReferenceCase IDref="Scenario-1"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-VSDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <SimpleImpactAnalysis>
+                    <ImpactOnOccupantComfort>Low</ImpactOnOccupantComfort>
+                    <EstimatedCost>Medium</EstimatedCost>
+                    <EstimatedAnnualSavings>Medium</EstimatedAnnualSavings>
+                    <EstimatedROI>High</EstimatedROI>
+                    <Priority>Medium</Priority>
+                  </SimpleImpactAnalysis>
+                </PackageOfMeasures>
+              </ScenarioType>
+            </Scenario>
+            <Scenario ID="Scenario-POM-LEDs-VSDs">
+              <ScenarioType>
+                <PackageOfMeasures ID="POM-LEDs-VSDs">
+                  <ReferenceCase IDref="Scenario-1"/>
+                  <MeasureIDs>
+                    <MeasureID IDref="Measure-LEDs"/>
+                    <MeasureID IDref="Measure-VSDs"/>
+                  </MeasureIDs>
+                  <CostCategory>Capital</CostCategory>
+                  <SimpleImpactAnalysis>
+                    <ImpactOnOccupantComfort>Low</ImpactOnOccupantComfort>
+                    <EstimatedCost>Medium</EstimatedCost>
+                    <EstimatedAnnualSavings>Medium</EstimatedAnnualSavings>
+                    <EstimatedROI>High</EstimatedROI>
+                    <Priority>Medium</Priority>
+                  </SimpleImpactAnalysis>
+                </PackageOfMeasures>
+              </ScenarioType>
+            </Scenario>
+          </Scenarios>
+          <Utilities>
+            <Utility ID="Utility-Electric">
+              <RateSchedules>
+                <RateSchedule ID="RateSchedule-Electricity">
+                  <TypeOfRateStructure>
+                    <FlatRate>
+                      <RatePeriods>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--01-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--01-01</ApplicableEndDateForEnergyRate>
+                          <ApplicableStartDateForDemandRate>--01-01</ApplicableStartDateForDemandRate>
+                          <ApplicableEndDateForDemandRate>--01-01</ApplicableEndDateForDemandRate>
+                          <EnergyCostRate>0.072500</EnergyCostRate>
+                          <ElectricDemandRate>0.000000</ElectricDemandRate>
+                        </RatePeriod>
+                      </RatePeriods>
+                    </FlatRate>
+                  </TypeOfRateStructure>
+                  <ReferenceForRateStructure>https://missoulaelectric.com/member-care/billing-payment/rates/</ReferenceForRateStructure>
+                  <FixedMonthlyCharge>28.000000</FixedMonthlyCharge>
+                </RateSchedule>
+              </RateSchedules>
+              <EIAUtilityID>12692</EIAUtilityID>
+              <UtilityName>Missoula Electric Cooperative</UtilityName>
+              <UtilityAccountNumber>some-account-number</UtilityAccountNumber>
+            </Utility>
+            <Utility ID="Utility-Natural-Gas">
+              <RateSchedules>
+                <RateSchedule ID="RateSchedule-Natural-Gas">
+                  <TypeOfRateStructure>
+                    <FlatRate>
+                      <RatePeriods>
+                        <RatePeriod>
+                          <ApplicableStartDateForEnergyRate>--01-01</ApplicableStartDateForEnergyRate>
+                          <ApplicableEndDateForEnergyRate>--01-01</ApplicableEndDateForEnergyRate>
+                          <EnergyCostRate>5.500000</EnergyCostRate>
+                        </RatePeriod>
+                      </RatePeriods>
+                    </FlatRate>
+                  </TypeOfRateStructure>
+                  <ReferenceForRateStructure>https://naturalgaslocal.com/states/montana/missoula/</ReferenceForRateStructure>
+                </RateSchedule>
+              </RateSchedules>
+              <UtilityName>NorthWestern Energy</UtilityName>
+              <UtilityAccountNumber>some-other-account-number</UtilityAccountNumber>
+            </Utility>
+          </Utilities>
+          <AuditorContactID IDref="Contact-Auditor"/>
+          <LinkedPremisesOrSystem>
+            <Building>
+              <LinkedBuildingID IDref="Building-Small-Office-Prototype"/>
+            </Building>
+          </LinkedPremisesOrSystem>
+        </Report>
+        <Report ID="Report-IAQ-MV">
+          <Scenarios>
+            <Scenario ID="IAQ">
+              <ScenarioType>
+                <CurrentBuilding/>
+              </ScenarioType>
+              <TimeSeriesData>
+                <TimeSeries ID="TS-IAQ-DBT-1">
+                  <ReadingType>Point</ReadingType>
+                  <TimeSeriesReadingQuantity>Dry Bulb Temperature</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2021-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2021-01-01T00:15:00</EndTimestamp>
+                  <IntervalFrequency>15 minute</IntervalFrequency>
+                  <IntervalReading>24.5</IntervalReading>
+                </TimeSeries>
+                <TimeSeries ID="TS-IAQ-Wind-1">
+                  <ReadingType>Average</ReadingType>
+                  <TimeSeriesReadingQuantity>Wind Speed</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2021-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2021-01-01T00:15:00</EndTimestamp>
+                  <IntervalFrequency>15 minute</IntervalFrequency>
+                  <IntervalReading>0.5</IntervalReading>
+                </TimeSeries>
+                <TimeSeries ID="TS-IAQ-DBT-2">
+                  <ReadingType>Point</ReadingType>
+                  <TimeSeriesReadingQuantity>Dry Bulb Temperature</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2021-01-01T00:15:00</StartTimestamp>
+                  <EndTimestamp>2021-01-01T00:30:00</EndTimestamp>
+                  <IntervalFrequency>15 minute</IntervalFrequency>
+                  <IntervalReading>25.5</IntervalReading>
+                </TimeSeries>
+              </TimeSeriesData>
+            </Scenario>
+          </Scenarios>
+        </Report>
+      </Reports>
+      <Contacts>
+        <Contact ID="Contact-Owner">
+          <ContactRoles>
+            <ContactRole>Owner</ContactRole>
+          </ContactRoles>
+          <ContactName>The dude</ContactName>
+          <ContactCompany>Some big company</ContactCompany>
+          <ContactEmailAddresses>
+            <ContactEmailAddress>
+              <EmailAddress>the.dude@somebigco.net</EmailAddress>
+            </ContactEmailAddress>
+          </ContactEmailAddresses>
+        </Contact>
+        <Contact ID="Contact-Auditor">
+          <ContactRoles>
+            <ContactRole>Energy Auditor</ContactRole>
+          </ContactRoles>
+          <ContactName>The lady</ContactName>
+          <ContactCompany>Auditeers</ContactCompany>
+          <ContactEmailAddresses>
+            <ContactEmailAddress>
+              <EmailAddress>the.lady@the-three-auditeers.com</EmailAddress>
+            </ContactEmailAddress>
+          </ContactEmailAddresses>
+        </Contact>
+      </Contacts>
+    </Facility>
+  </Facilities>
+</BuildingSync>

--- a/docs/notebooks/example1-with-sensors.xml
+++ b/docs/notebooks/example1-with-sensors.xml
@@ -227,7 +227,7 @@
                     <Emission>
                       <EmissionBoundary>Indirect</EmissionBoundary>
                       <EmissionsType>CO2e</EmissionsType>
-                      <GHGEmissions>TOTAL FROM OUR TIME SERIES</GHGEmissions>
+                      <GHGEmissions>25000</GHGEmissions>
                       <EmissionsLinkedTimeSeriesIDs>
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-1"/>
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-2"/>
@@ -989,7 +989,7 @@
                   <SiteEnergyUseIntensity>37.800000</SiteEnergyUseIntensity>
                   <EnergyCost>4451.510000</EnergyCost>
                   <EnergyCostIndex>0.810000</EnergyCostIndex>
-                  <AnnualAverageCarbonEmissions>kgCO2e  -  10000 </AnnualAverageCarbonEmissions>
+                  <AnnualAverageCarbonEmissions>10000</AnnualAverageCarbonEmissions>
                   <AnnualMarginalCarbonEmissions>8000</AnnualMarginalCarbonEmissions>
                 </AllResourceTotal>
               </AllResourceTotals>
@@ -1039,7 +1039,7 @@
                     <Emission>
                       <EmissionBoundary>Indirect</EmissionBoundary>
                       <EmissionsType>CO2e</EmissionsType>
-                      <GHGEmissions>TOTAL FROM OUR TIME SERIES</GHGEmissions>
+                      <GHGEmissions>8000</GHGEmissions>
                       <EmissionsLinkedTimeSeriesIDs>
                         <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-1"/>
                         <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-2"/>
@@ -1289,8 +1289,8 @@
                   <SiteEnergyUseIntensity>35.800000</SiteEnergyUseIntensity>
                   <EnergyCost>4300.510000</EnergyCost>
                   <EnergyCostIndex>0.710000</EnergyCostIndex>
-                  <AnnualAverageCarbonEmissions>9000 </AnnualAverageCarbonEmissions>
-                  <AnnualMarginalCarbonEmissions>7000 </AnnualMarginalCarbonEmissions>
+                  <AnnualAverageCarbonEmissions>9000</AnnualAverageCarbonEmissions>
+                  <AnnualMarginalCarbonEmissions>7000</AnnualMarginalCarbonEmissions>
                 </AllResourceTotal>
               </AllResourceTotals>
             </Scenario>

--- a/docs/notebooks/example1-with-sensors.xml
+++ b/docs/notebooks/example1-with-sensors.xml
@@ -234,7 +234,13 @@
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-3"/>
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-4"/>
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-5"/>
-                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-..."/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-6"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-7"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-8"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-9"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-10"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-11"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-12"/>
                       </EmissionsLinkedTimeSeriesIDs>
                     </Emission>
                   </Emissions>
@@ -816,12 +822,111 @@
                 </TimeSeries>
                 <TimeSeries ID="TS-ResourceUse-CO2e-1">
                   <ReadingType>Total</ReadingType>
-                  <TimeSeriesReadingQuantity>Emissions | CO2e <-NEW </TimeSeriesReadingQuantity>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
                   <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
                   <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
                   <IntervalFrequency>Month</IntervalFrequency>
                   <IntervalReading>250</IntervalReading>
-                  <ResourceUseID IDref="ResourceUse-Emissions"/>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>240</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>260</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>260</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>230</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>280</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>270</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>260</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>240</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Electricity"/>
                 </TimeSeries>
               </TimeSeriesData>
               <AllResourceTotals>
@@ -838,8 +943,8 @@
                   <NetIncreaseInStoredEnergyConsistentUnits>0.000000</NetIncreaseInStoredEnergyConsistentUnits>
                   <EnergyCost>5395.000000</EnergyCost>
                   <EnergyCostIndex>0.980000</EnergyCostIndex>
-                  <AnnualAverageCarbonEmissions>kgCO2e  - 15000</AnnualAverageCarbonEmissions>
-                  <AnnualMarginalCarbonEmissions>kgCO2e    -  25000 </AnnualMarginalCarbonEmissions>
+                  <AnnualAverageCarbonEmissions>15000</AnnualAverageCarbonEmissions>
+                  <AnnualMarginalCarbonEmissions>25000 </AnnualMarginalCarbonEmissions>
                 </AllResourceTotal>
               </AllResourceTotals>
             </Scenario>
@@ -901,32 +1006,290 @@
                     <EstimatedROI>High</EstimatedROI>
                     <Priority>Medium</Priority>
                   </SimpleImpactAnalysis>
-                  <AnnualSavingsByFuels>
-                    <AnnualSavingsByFuel>
-                      <EnergyResource>Electricity</EnergyResource>
-                      <AnnualSavingsNativeUnits>12050</AnnualSavingsNativeUnits>
-                      <ResourceUnits>kgCO2e <_-- NEW</ResourceUnits>
-                      <Emissions <--- new section >
-                        <Emission>
-                          <EmissionBoundary>Indirect</EmissionBoundary>
-                          <EmissionsType>CO2e</EmissionsType>
-                          <GHGEmissions>TOTAL SAVINGS OVER REFERDCNE CASE</GHGEmissions>
-                          <EmissionsLinkedTimeSeriesIDs <<< IS THIS WHERE wwe are saving timeseries>
-                            <LinkedTimeSeriesID IDref="TS-ResourceUse-Savings-CO2e-1"/>
-                            <LinkedTimeSeriesID IDref="TS-ResourceUse-Savings-CO2e-2"/>
-                            <LinkedTimeSeriesID IDref="TS-ResourceUse-Savings-CO2e-3"/>
-                          </EmissionsLinkedTimeSeriesIDs>
-                        </Emission>
-                      </Emissions>
-                    </AnnualSavingsByFuel>
-                  </AnnualSavingsByFuels>
+                  <AnnualSavingsAverageCarbonEmissions>600</AnnualSavingsAverageCarbonEmissions>
+                  <AnnualSavingsMarginalCarbonEmissions>210</AnnualSavingsMarginalCarbonEmissions>
                 </PackageOfMeasures>
               </ScenarioType>
+              <ResourceUses>
+                <ResourceUse ID="POM-LEDs-RU-Electricity">
+                  <EnergyResource>Electricity</EnergyResource>
+                  <ResourceUseNotes>This is required for L1 to document irregularities in monthly energy patterns (Std 211 6.1.2.1.j). No irregularities found.</ResourceUseNotes>
+                  <ResourceUnits>kWh</ResourceUnits>
+                  <EndUse>All end uses</EndUse>
+                  <AnnualFuelUseNativeUnits>50000</AnnualFuelUseNativeUnits>
+                  <AnnualFuelUseConsistentUnits>234.000000</AnnualFuelUseConsistentUnits>
+                  <AnnualFuelUseLinkedTimeSeriesIDs>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-1"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-2"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-3"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-4"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-5"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-6"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-7"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-8"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-9"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-10"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-11"/>
+                    <LinkedTimeSeriesID IDref="POM-LEDs-RU-Electricity-Energy-12"/>
+                  </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <Emissions>
+                    <Emission>
+                      <EmissionBoundary>Indirect</EmissionBoundary>
+                      <EmissionsType>CO2e</EmissionsType>
+                      <GHGEmissions>TOTAL FROM OUR TIME SERIES</GHGEmissions>
+                      <EmissionsLinkedTimeSeriesIDs>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-1"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-2"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-3"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-4"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-5"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-6"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-7"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-8"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-9"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-10"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-11"/>
+                        <LinkedTimeSeriesID IDref="POM-LEDs-RU-CO2e-12"/>
+                      </EmissionsLinkedTimeSeriesIDs>
+                    </Emission>
+                  </Emissions>
+                  <PeakResourceUnits>kW</PeakResourceUnits>
+                  <AnnualPeakNativeUnits>18.120000</AnnualPeakNativeUnits>
+                  <AnnualPeakConsistentUnits>18.120000</AnnualPeakConsistentUnits>
+                  <AnnualFuelCost>4500.000000</AnnualFuelCost>
+                  <UtilityIDs>
+                    <UtilityID IDref="Utility-Electric"/>
+                  </UtilityIDs>
+                </ResourceUse>
+              </ResourceUses>
               <TimeSeriesData>
-                <TimeSeries ID="TS-ResourceUse-Savings-CO2e-1">
-                  <ReadingType>Value</ReadingType>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6792.890000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5841.750000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6025.190000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>4985.300000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5184.040000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5358.550000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5755.670000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5981.780000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5401.940000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5225.840000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2019-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>5672.150000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-Electricity-Energy-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Energy</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>6291.630000</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>280</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-2">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-01-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-02-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>240</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-3">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-02-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-03-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-4">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-03-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-04-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>260</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-5">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-04-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-05-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>280</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-6">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-05-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-06-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>270</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-7">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-06-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-07-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-8">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-07-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-08-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>220</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-9">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-08-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-09-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>230</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-10">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-09-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-10-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-11">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-10-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-11-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>280</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
+                </TimeSeries>
+                <TimeSeries ID="POM-LEDs-RU-CO2e-12">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions</TimeSeriesReadingQuantity>
+                  <StartTimestamp>2020-11-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-12-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>300</IntervalReading>
+                  <ResourceUseID IDref="POM-LEDs-RU-Electricity"/>
                 </TimeSeries>
               </TimeSeriesData>
+              <AllResourceTotals>
+                <AllResourceTotal ID="AllResourceTotal-Target">
+                  <SiteEnergyUse>200000.500000</SiteEnergyUse>
+                  <SiteEnergyUseIntensity>35.800000</SiteEnergyUseIntensity>
+                  <EnergyCost>4300.510000</EnergyCost>
+                  <EnergyCostIndex>0.710000</EnergyCostIndex>
+                  <AnnualAverageCarbonEmissions>9000 </AnnualAverageCarbonEmissions>
+                  <AnnualMarginalCarbonEmissions>7000 </AnnualMarginalCarbonEmissions>
+                </AllResourceTotal>
+              </AllResourceTotals>
             </Scenario>
             <Scenario ID="Scenario-POM-VSDs">
               <ScenarioType>

--- a/docs/notebooks/example1-with-sensors.xml
+++ b/docs/notebooks/example1-with-sensors.xml
@@ -223,6 +223,21 @@
                     <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-11"/>
                     <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Energy-12"/>
                   </AnnualFuelUseLinkedTimeSeriesIDs>
+                  <Emissions>
+                    <Emission>
+                      <EmissionBoundary>Indirect</EmissionBoundary>
+                      <EmissionsType>CO2e</EmissionsType>
+                      <GHGEmissions>TOTAL FROM OUR TIME SERIES</GHGEmissions>
+                      <EmissionsLinkedTimeSeriesIDs>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-1"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-2"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-3"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-4"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-5"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-..."/>
+                      </EmissionsLinkedTimeSeriesIDs>
+                    </Emission>
+                  </Emissions>
                   <PeakResourceUnits>kW</PeakResourceUnits>
                   <AnnualPeakNativeUnits>21.120000</AnnualPeakNativeUnits>
                   <AnnualPeakConsistentUnits>21.120000</AnnualPeakConsistentUnits>
@@ -799,6 +814,15 @@
                   <IntervalReading>32.470000</IntervalReading>
                   <ResourceUseID IDref="ResourceUse-Natural-gas"/>
                 </TimeSeries>
+                <TimeSeries ID="TS-ResourceUse-CO2e-1">
+                  <ReadingType>Total</ReadingType>
+                  <TimeSeriesReadingQuantity>Emissions | CO2e <-NEW </TimeSeriesReadingQuantity>
+                  <StartTimestamp>2019-12-01T00:00:00</StartTimestamp>
+                  <EndTimestamp>2020-01-01T00:00:00</EndTimestamp>
+                  <IntervalFrequency>Month</IntervalFrequency>
+                  <IntervalReading>250</IntervalReading>
+                  <ResourceUseID IDref="ResourceUse-Emissions"/>
+                </TimeSeries>
               </TimeSeriesData>
               <AllResourceTotals>
                 <AllResourceTotal ID="AllResourceTotal-1">
@@ -814,6 +838,8 @@
                   <NetIncreaseInStoredEnergyConsistentUnits>0.000000</NetIncreaseInStoredEnergyConsistentUnits>
                   <EnergyCost>5395.000000</EnergyCost>
                   <EnergyCostIndex>0.980000</EnergyCostIndex>
+                  <AnnualAverageCarbonEmissions>kgCO2e  - 15000</AnnualAverageCarbonEmissions>
+                  <AnnualMarginalCarbonEmissions>kgCO2e    -  25000 </AnnualMarginalCarbonEmissions>
                 </AllResourceTotal>
               </AllResourceTotals>
             </Scenario>
@@ -841,9 +867,12 @@
               <ScenarioType>
                 <Target>
                   <ReferenceCase IDref="Scenario-Benchmark"/>
+                  <ReferenceEndDate>2025-12-31</ReferenceEndDate>
                   <AnnualSavingsSiteEnergy>67181.500000</AnnualSavingsSiteEnergy>
                   <AnnualSavingsCost>931</AnnualSavingsCost>
                   <ENERGYSTARScore>70.000000</ENERGYSTARScore>
+                  <AnnualSavingsAverageCarbonEmissions>500</AnnualSavingsAverageCarbonEmissions>
+                  <AnnualSavingsMarginalCarbonEmissions>200</AnnualSavingsMarginalCarbonEmissions>
                 </Target>
               </ScenarioType>
               <AllResourceTotals>
@@ -852,6 +881,8 @@
                   <SiteEnergyUseIntensity>37.800000</SiteEnergyUseIntensity>
                   <EnergyCost>4451.510000</EnergyCost>
                   <EnergyCostIndex>0.810000</EnergyCostIndex>
+                  <AnnualAverageCarbonEmissions>kgCO2e  -  10000 </AnnualAverageCarbonEmissions>
+                  <AnnualMarginalCarbonEmissions>kgCO2e  -  8000 </AnnualMarginalCarbonEmissions>
                 </AllResourceTotal>
               </AllResourceTotals>
             </Scenario>
@@ -870,8 +901,32 @@
                     <EstimatedROI>High</EstimatedROI>
                     <Priority>Medium</Priority>
                   </SimpleImpactAnalysis>
+                  <AnnualSavingsByFuels>
+                    <AnnualSavingsByFuel>
+                      <EnergyResource>Electricity</EnergyResource>
+                      <AnnualSavingsNativeUnits>12050</AnnualSavingsNativeUnits>
+                      <ResourceUnits>kgCO2e <_-- NEW</ResourceUnits>
+                      <Emissions <--- new section >
+                        <Emission>
+                          <EmissionBoundary>Indirect</EmissionBoundary>
+                          <EmissionsType>CO2e</EmissionsType>
+                          <GHGEmissions>TOTAL SAVINGS OVER REFERDCNE CASE</GHGEmissions>
+                          <EmissionsLinkedTimeSeriesIDs <<< IS THIS WHERE wwe are saving timeseries>
+                            <LinkedTimeSeriesID IDref="TS-ResourceUse-Savings-CO2e-1"/>
+                            <LinkedTimeSeriesID IDref="TS-ResourceUse-Savings-CO2e-2"/>
+                            <LinkedTimeSeriesID IDref="TS-ResourceUse-Savings-CO2e-3"/>
+                          </EmissionsLinkedTimeSeriesIDs>
+                        </Emission>
+                      </Emissions>
+                    </AnnualSavingsByFuel>
+                  </AnnualSavingsByFuels>
                 </PackageOfMeasures>
               </ScenarioType>
+              <TimeSeriesData>
+                <TimeSeries ID="TS-ResourceUse-Savings-CO2e-1">
+                  <ReadingType>Value</ReadingType>
+                </TimeSeries>
+              </TimeSeriesData>
             </Scenario>
             <Scenario ID="Scenario-POM-VSDs">
               <ScenarioType>

--- a/docs/notebooks/example1-with-sensors.xml
+++ b/docs/notebooks/example1-with-sensors.xml
@@ -944,7 +944,7 @@
                   <EnergyCost>5395.000000</EnergyCost>
                   <EnergyCostIndex>0.980000</EnergyCostIndex>
                   <AnnualAverageCarbonEmissions>15000</AnnualAverageCarbonEmissions>
-                  <AnnualMarginalCarbonEmissions>25000 </AnnualMarginalCarbonEmissions>
+                  <AnnualMarginalCarbonEmissions>25000</AnnualMarginalCarbonEmissions>
                 </AllResourceTotal>
               </AllResourceTotals>
             </Scenario>

--- a/docs/notebooks/example1-with-sensors.xml
+++ b/docs/notebooks/example1-with-sensors.xml
@@ -229,7 +229,7 @@
                       <EmissionsType>CO2e</EmissionsType>
                       <GHGEmissions>25000</GHGEmissions>
                       <EmissionsLinkedTimeSeriesIDs>
-                        <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-1"/>
+                        <LinkedTimeSeriesID IDref="TS-ResourceUse-Electricity-Greenhouse Gas Emissions-1"/>
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-2"/>
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-3"/>
                         <LinkedTimeSeriesID IDref="TS-ResourceUse-CO2e-4"/>

--- a/docs/notebooks/example1-with-sensors.xml
+++ b/docs/notebooks/example1-with-sensors.xml
@@ -990,7 +990,7 @@
                   <EnergyCost>4451.510000</EnergyCost>
                   <EnergyCostIndex>0.810000</EnergyCostIndex>
                   <AnnualAverageCarbonEmissions>kgCO2e  -  10000 </AnnualAverageCarbonEmissions>
-                  <AnnualMarginalCarbonEmissions>kgCO2e  -  8000 </AnnualMarginalCarbonEmissions>
+                  <AnnualMarginalCarbonEmissions>8000</AnnualMarginalCarbonEmissions>
                 </AllResourceTotal>
               </AllResourceTotals>
             </Scenario>

--- a/proposals/2022/Add Emissions.md
+++ b/proposals/2022/Add Emissions.md
@@ -23,7 +23,7 @@ This proposal is to add several Emissions related fields to the BuildingSync sch
 
 ## Justification
 
-The BuildingSync schema needs to be modified to accommodate a standard way of reporting GHG emissions (in kg CO2e) to support the focus on decarbonization efforts.
+The BuildingSync schema needs to be modified to accommodate a standard way of reporting GHG emissions (in MtCO2e) to support the focus on decarbonization efforts.
 
 ## Implementation
 

--- a/proposals/2022/Add Emissions.md
+++ b/proposals/2022/Add Emissions.md
@@ -30,7 +30,7 @@ The BuildingSync schema needs to be modified to accommodate a standard way of re
 ```xml
  <xs:element name="AnnualSavingsAverageGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Average GHG emissions savings per year. (kg CO2e/year)</xs:documentation>
+      <xs:documentation>Average GHG emissions savings per year. (MtCO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>
@@ -42,7 +42,7 @@ The BuildingSync schema needs to be modified to accommodate a standard way of re
   </xs:element>
   <xs:element name="AnnualSavingsMarginalGHGEmissions">
     <xs:annotation>
-      <xs:documentation>Marginal GHG emissions savings per year. (kg CO2e/year)</xs:documentation>
+      <xs:documentation>Marginal GHG emissions savings per year. (MtCO2e/year)</xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:simpleContent>

--- a/proposals/2022/Add Emissions.md
+++ b/proposals/2022/Add Emissions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This proposal is to add several Emissions related fields to the BuildingSync schema to capture information on GHG emissions, specifically CO2e in units of MtCO2e. 
+This proposal is to add several Emissions related fields to the BuildingSync schema to capture information on GHG emissions, in units of MtCO2e. 
 
 1. Added to AllResourceTotal:
 	- AnnualAverageGHGEmissions

--- a/proposals/2022/Add Emissions.md
+++ b/proposals/2022/Add Emissions.md
@@ -1,0 +1,84 @@
+# Add Emissions Fields
+
+## Overview
+
+This proposal is to add several Emissions related fields to the BuildingSync schema to capture information on carbon emissions, specifically CO2e in units of kg of CO2e. 
+
+1. Added to AllResourceTotal:
+	- AnnualAverageCarbonEmissions
+	- AnnualMarginalCarbonEmissions
+1. Added to ResourceUse -> Emissions -> Emission:
+	- EmissionsLinkedTimeSeriesIDs -> EmissionsLinkedTimeSeriesID
+1. Added to TimeSeries -> TimeSeriesReadingQuantity
+	- Enum "Emissions"
+1. Scenario Type changes by scenario_type:
+	1. Added to ScenarioType -> CurrentBuilding, ScenarioType -> Benchmark, and ScenarioType -> Derived Model
+		- no changes
+	1. Added to ScenarioType -> Target, ScenarioType -> PackageOfMeasures, and ScenarioType -> Other:
+		- AnnualSavingsAverageCarbonEmissions
+		- AnnualSavingsMarginalCarbonEmissions
+
+## Justification
+
+The BuildingSync schema needs to be modify to accomodate a standard way of reporting carbon emissions (in kg CO2e) to support the focus on decarbonization efforts.
+
+## Implementation
+
+```xml
+ <xs:element name="AnnualSavingsAverageCarbonEmissions">
+    <xs:annotation>
+      <xs:documentation>Average carbon emissions savings per year. (kg CO2e/year)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AnnualSavingsMarginalCarbonEmissions">
+    <xs:annotation>
+      <xs:documentation>Marginal carbon emissions savings per year. (kg CO2e/year)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+```
+```xml
+ <xs:element name="Emissions" minOccurs="0">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="Emission" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+          	
+          	...
+
+          	<xs:element minOccurs="0" name="EmissionsLinkedTimeSeriesIDs">
+              <xs:annotation>
+                <xs:documentation>Links to all time series data used to calculate the GHGEmissions</xs:documentation>
+              </xs:annotation>
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element maxOccurs="unbounded" minOccurs="1" name="EmissionsLinkedTimeSeriesID">
+                    <xs:complexType>
+                      <xs:attribute name="IDref" type="xs:IDREF"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:element>
+```
+

--- a/proposals/2022/Add Emissions.md
+++ b/proposals/2022/Add Emissions.md
@@ -7,8 +7,10 @@ This proposal is to add several Emissions related fields to the BuildingSync sch
 1. Added to AllResourceTotal:
 	- AnnualAverageGHGEmissions
 	- AnnualMarginalGHGEmissions
+  - AnnualGHGEmissionIntensity
 1. Added to ResourceUse -> Emissions -> Emission:
 	- EmissionsLinkedTimeSeriesIDs -> EmissionsLinkedTimeSeriesID
+  - **changed units on AvoidedEmissions from kgCO2e to MtCO2e to be consistent with GHG metric definition**
 1. Added to TimeSeries -> TimeSeriesReadingQuantity
 	- Enum "Emissions"
 1. Scenario Type changes by scenario_type:
@@ -17,6 +19,7 @@ This proposal is to add several Emissions related fields to the BuildingSync sch
 	1. Added to ScenarioType -> Target, ScenarioType -> PackageOfMeasures, and ScenarioType -> Other:
 		- AnnualSavingsAverageGHGEmissions
 		- AnnualSavingsMarginalGHGEmissions
+    - AnnualSavingsGHGEmissionIntensity
 
 ## Justification
 
@@ -49,7 +52,59 @@ The BuildingSync schema needs to be modified to accommodate a standard way of re
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
+  <xs:element name="AnnualSavingsGHGEmissionIntensity">
+    <xs:annotation>
+      <xs:documentation>Annual GHG emissions intensity savings per year. (kg CO2e/ft2/year)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
 ```
+```xml
+  <xs:element name="AnnualAverageGHGEmissions" minOccurs="0">
+    <xs:annotation>
+      <xs:documentation>Annual Average GHG Emissions. (MtCO2e)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AnnualMarginalGHGEmissions" minOccurs="0">
+    <xs:annotation>
+      <xs:documentation>Annual Marginal GHG Emissions. (MtCO2e)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AnnualGHGEmissionIntensity" minOccurs="0">
+    <xs:annotation>
+      <xs:documentation>Annual GHG Emission Intensity. (kg CO2e/ft2/year)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:decimal">
+          <xs:attribute ref="auc:Source"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+```
+
 ```xml
  <xs:element name="Emissions" minOccurs="0">
   <xs:complexType>

--- a/proposals/2022/Add Emissions.md
+++ b/proposals/2022/Add Emissions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This proposal is to add several Emissions related fields to the BuildingSync schema to capture information on GHG emissions, specifically CO2e in units of kg of CO2e. 
+This proposal is to add several Emissions related fields to the BuildingSync schema to capture information on GHG emissions, specifically CO2e in units of MtCO2e. 
 
 1. Added to AllResourceTotal:
 	- AnnualAverageGHGEmissions
@@ -10,7 +10,6 @@ This proposal is to add several Emissions related fields to the BuildingSync sch
   - AnnualGHGEmissionIntensity
 1. Added to ResourceUse -> Emissions -> Emission:
 	- EmissionsLinkedTimeSeriesIDs -> EmissionsLinkedTimeSeriesID
-  - **changed units on AvoidedEmissions from kgCO2e to MtCO2e to be consistent with GHG metric definition**
 1. Added to TimeSeries -> TimeSeriesReadingQuantity
 	- Enum "Emissions"
 1. Scenario Type changes by scenario_type:


### PR DESCRIPTION
Adding CO2e fields.

1. Added to AllResourceTotal: 
	1. AnnualAverageCarbonEmissions
	2. AnnualMarginalCarbonEmissions
2. Added to ResourceUse -> Emissions -> Emission:
	1. EmissionsLinkedTimeSeriesIDs -> EmissionsLinkedTimeSeriesID
3. Added to TimeSeries -> TimeSeriesReadingQuantity
	1. Enum "Emissions"
4. SCENARIO TYPES changes:
	1. Added to ScenarioType -> CurrentBuilding:
		1. Nothing
	2. Added to ScenarioType -> Benchmark:
		1. Nothing
	3. Added to ScenarioType -> Target:
		1. AnnualSavingsAverageCarbonEmissions
		2. AnnualSavingsMarginalCarbonEmissions
	4. Added to ScenarioType -> PackageOfMeasures:
		1. AnnualSavingsAverageCarbonEmissions
		2. AnnualSavingsMarginalCarbonEmissions
        5. Added to ScenarioType -> Other:
	        1. AnnualSavingsAverageCarbonEmissions
	        2. AnnualSavingsMarginalCarbonEmissions
	6. Added ScenarioType -> DerivedModel :
	        1. Nothing

Resolves https://github.com/BuildingSync/project-tracker/issues/94