### PR TITLE
Add PrincipalLightingSystemType

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -7341,7 +7341,7 @@
   </xs:complexType>
   <xs:element name="PrincipalLightingSystemType">
     <xs:annotation>
-      <xs:documentation>Principal Lighting type for a building or a section.</xs:documentation>
+      <xs:documentation>Principal Lighting type for a building or a section. The usage of this element is not recommended except for Audit Template use cases.</xs:documentation>
     </xs:annotation>
     <xs:simpleType>
       <xs:restriction base="xs:string">
@@ -7351,6 +7351,16 @@
         <xs:enumeration value="Halogen"/>
         <xs:enumeration value="High Intensity Discharge"/>
         <xs:enumeration value="Solid State Lighting"/>
+        <xs:enumeration value="LED"/>
+        <xs:enumeration value="Mercury Vapor"/>
+        <xs:enumeration value="Metal Halide"/>
+        <xs:enumeration value="Sodium Vapor High Pressure"/>
+        <xs:enumeration value="T5"/>
+        <xs:enumeration value="T5HO"/>
+        <xs:enumeration value="T8"/>
+        <xs:enumeration value="Super T8"/>
+        <xs:enumeration value="T12"/>
+        <xs:enumeration value="T12HO"/>
         <xs:enumeration value="Induction"/>
         <xs:enumeration value="Neon"/>
         <xs:enumeration value="Plasma"/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -849,6 +849,7 @@
         </xs:complexType>
       </xs:element>
       <xs:element ref="auc:YearOfConstruction" minOccurs="0"/>
+      <xs:element ref="auc:PrincipalLightingSystemType" minOccurs="0"/>
       <xs:element name="YearOccupied" type="xs:gYear" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Year in which the premises was first occupied. (CCYY)</xs:documentation>
@@ -959,6 +960,7 @@
                   <xs:element ref="auc:SpatialUnits" minOccurs="0"/>
                   <xs:element ref="auc:PrimaryContactID" minOccurs="0"/>
                   <xs:element ref="auc:TenantIDs" minOccurs="0" maxOccurs="unbounded"/>
+                  <xs:element ref="auc:PrincipalLightingSystemType" minOccurs="0"/>
                   <xs:element ref="auc:YearOfConstruction" minOccurs="0"/>
                   <xs:element name="FootprintShape" minOccurs="0">
                     <xs:annotation>
@@ -7337,6 +7339,28 @@
     <xs:attribute name="ID" type="xs:ID" use="required"/>
     <xs:attribute ref="auc:Status"/>
   </xs:complexType>
+  <xs:element name="PrincipalLightingSystemType">
+    <xs:annotation>
+      <xs:documentation>Principal Lighting type for a building or a section.</xs:documentation>
+    </xs:annotation>
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:enumeration value="Incandescent"/>
+        <xs:enumeration value="Linear Fluorescent"/>
+        <xs:enumeration value="Compact Fluorescent"/>
+        <xs:enumeration value="Halogen"/>
+        <xs:enumeration value="High Intensity Discharge"/>
+        <xs:enumeration value="Solid State Lighting"/>
+        <xs:enumeration value="Induction"/>
+        <xs:enumeration value="Neon"/>
+        <xs:enumeration value="Plasma"/>
+        <xs:enumeration value="Photoluminescent"/>
+        <xs:enumeration value="Self Luminous"/>
+        <xs:enumeration value="Other"/>
+        <xs:enumeration value="Unknown"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
   <xs:complexType name="DomesticHotWaterSystemType">
     <xs:sequence>
       <xs:element name="DomesticHotWaterType" minOccurs="0">

--- a/proposals/2023/Add PrincipalLightingSystemType.md
+++ b/proposals/2023/Add PrincipalLightingSystemType.md
@@ -42,6 +42,6 @@ From `auc:LampType`:
 The combined options might have overlaps (e.g. LED and Solid State Lighting).
 
 ## Decision
-We add this element to avoid the usage of UDF for a commonly used element in AT and improve the data transferability between AT and BS. However we don't recommend the usage of this element other than the use case of input/output to/from Audit Template.
+We add this element to avoid the usage of UDF for a commonly used element in AT and improve the data transferability between AT and BuildingSync. However we don't recommend the usage of this element other than the use case of input/output to/from Audit Template.
 
 ## References

--- a/proposals/2023/Add PrincipalLightingSystemType.md
+++ b/proposals/2023/Add PrincipalLightingSystemType.md
@@ -1,0 +1,31 @@
+# Add PrincipalLightingSystemType
+
+## Overview
+
+This proposal is to add the element `auc:PrincipalLightingSystemType` element under the `auc:Building` and `auc:Section` element.
+
+## Justification
+
+The Audit Template Tool requires this element living directly under building and section level. Due to the hierarchy structural difference between AT and BS, AT can not map `auc:LampType` to their Principal Lighting System Type field under Building or Section, so previously a UDF was used for this. However adding this element does not align with the current structure of BuildingSync, which separates `auc:Facilities` and `auc:Systems` and applies relationship via linking elements - it introduces a "system" element into the `auc:Facilities`.
+
+## Implementation
+Add the element `auc:PrincipalLightingSystemType` globally, and refer it under `auc:Building` and `auc:Section`.
+The enumerations of the added elements are converted from the child elements of `auc:LampType`, which are 
+* Incandescent
+* Linear Fluorescent
+* Compact Fluorescent
+* Halogen
+* High Intensity Discharge
+* Solid State Lighting
+* Induction
+* Neon
+* Plasma
+* Photoluminescent
+* SelfLuminous
+* Other
+* Unknown
+
+## Decision
+We add this element to avoid the usage of UDF for a commonly used element in AT and improve the data transferability between AT and BS. However we don't recommend the usage of this element other than the use case of input/output to/from Audit Template.
+
+## References

--- a/proposals/2023/Add PrincipalLightingSystemType.md
+++ b/proposals/2023/Add PrincipalLightingSystemType.md
@@ -10,7 +10,22 @@ The Audit Template Tool requires this element living directly under building and
 
 ## Implementation
 Add the element `auc:PrincipalLightingSystemType` globally, and refer it under `auc:Building` and `auc:Section`.
-The enumerations of the added elements are converted from the child elements of `auc:LampType`, which are 
+The enumerations of the added elements are combined by sources from Audit Template library and the child elements of `auc:LampType`.
+From Audit Template:
+* Compact Fluorescent
+* Halogen
+* Incandescent
+* LED
+* Mercury Vapor
+* Metal Halide
+* Sodium Vapor High Pressure
+* T5
+* T5HO
+* T8
+* Super T8
+* T12
+* T12HO
+From `auc:LampType`: 
 * Incandescent
 * Linear Fluorescent
 * Compact Fluorescent
@@ -24,6 +39,7 @@ The enumerations of the added elements are converted from the child elements of 
 * SelfLuminous
 * Other
 * Unknown
+The combined options might have overlaps (e.g. LED and Solid State Lighting).
 
 ## Decision
 We add this element to avoid the usage of UDF for a commonly used element in AT and improve the data transferability between AT and BS. However we don't recommend the usage of this element other than the use case of input/output to/from Audit Template.


### PR DESCRIPTION
See proposal

#### Any background context you want to provide?

#### What does this PR do?
To add `PrincipalLightingSystemType` under `Building` and `Section` to enable direct mapping to/from Audit Template Tool, and omit the usage of UDF. However we do not recommend using this element other than AT use case, Instead, in BuildingSync world, we recommend using `System/LightingSystems/LightingSystem/LampType` to specify lighting type and link it to the correponding `Building` or `Section` via `LightingSystem/LinkedPremises`.

#### How should this be manually tested?
To do: need to confirm if the enumerations mapped correctly to AT library.
To do: need to make sure the usage of referencing global element is correct.
To do: test for schema and example validity.

#### What are the relevant tickets?
#470 
