### PR TITLE
Add WCM categories

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -4469,6 +4469,9 @@
                               <xs:enumeration value="Use discharged water from water purification processes"/>
                               <xs:enumeration value="Install foundation water treatment for reuse"/>
                               <xs:enumeration value="Install greywater reuse system"/>
+                              <xs:enumeration value="Clean and/or repair"/>
+                              <xs:enumeration value="Implement training and/or documentation"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4497,6 +4500,9 @@
                               <xs:enumeration value="Install WaterSense-qualified pre-rinse spray valves"/>
                               <xs:enumeration value="Install in-line flow restrictor on dipper wells"/>
                               <xs:enumeration value="Install steam kettle with condensate return"/>
+                              <xs:enumeration value="Clean and/or repair"/>
+                              <xs:enumeration value="Implement training and/or documentation"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4529,6 +4535,9 @@
                               <xs:enumeration value="Install water-efficient vivarium washing equipment with advanced controls and water recycling"/>
                               <xs:enumeration value="Install water-efficient vivarium watering equipment with recirculation system"/>
                               <xs:enumeration value="Install steam sterilizer condensate retrofit kit"/>
+                              <xs:enumeration value="Clean and/or repair"/>
+                              <xs:enumeration value="Implement training and/or documentation"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4558,6 +4567,9 @@
                               <xs:enumeration value="Remove or Recirculate ornamental water feature"/>
                               <xs:enumeration value="Install native/adaptive plants"/>
                               <xs:enumeration value="Remove high water consuming plants or replace with native/adaptive plants"/>
+                              <xs:enumeration value="Clean and/or repair"/>
+                              <xs:enumeration value="Implement training and/or documentation"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -4587,6 +4599,9 @@
                               <xs:enumeration value="Install water-efficient industrial/commercial laundry equipment"/>
                               <xs:enumeration value="Retrofit laundry washing equipment with water recycling system"/>
                               <xs:enumeration value="Install meter on vehicle wash system"/>
+                              <xs:enumeration value="Clean and/or repair"/>
+                              <xs:enumeration value="Implement training and/or documentation"/>
+                              <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -4595,7 +4595,7 @@
                               <xs:enumeration value="Install high-pressure self-service vehicle washer"/>
                               <xs:enumeration value="Install ozone system for laundry equipment"/>
                               <xs:enumeration value="Install water-efficient conveyor/in-bay vehicle washing equipment"/>
-                              <xs:enumeration value="Install Energy STAR-qualified laundry washing machines"/>
+                              <xs:enumeration value="Install ENERGY STAR-qualified laundry washing machines"/>
                               <xs:enumeration value="Install water-efficient industrial/commercial laundry equipment"/>
                               <xs:enumeration value="Retrofit laundry washing equipment with water recycling system"/>
                               <xs:enumeration value="Install meter on vehicle wash system"/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -4448,6 +4448,152 @@
                       </xs:sequence>
                     </xs:complexType>
                   </xs:element>
+                  <xs:element name="AlternativeWaterSources" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Alternative water sources options for water saving.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="MeasureName" maxOccurs="unbounded">
+                          <xs:annotation>
+                            <xs:documentation>Short description of measure.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="Install condensate capture equipment"/>
+                              <xs:enumeration value="Install atmospheric water generator"/>
+                              <xs:enumeration value="Install wastewater treatment plant"/>
+                              <xs:enumeration value="Install rainwater harvesting system"/>
+                              <xs:enumeration value="Install cooling tower blowdown for appropriate applications"/>
+                              <xs:enumeration value="Install desalinated water treatment for reuse"/>
+                              <xs:enumeration value="Use discharged water from water purification processes"/>
+                              <xs:enumeration value="Install foundation water treatment for reuse"/>
+                              <xs:enumeration value="Install greywater reuse system"/>
+                              <xs:enumeration value="Other"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="KitchenImprovements" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Kitchen improvements.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="MeasureName" maxOccurs="unbounded">
+                          <xs:annotation>
+                            <xs:documentation>Short description of measure.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="Retrofit single-pass cooling ice machine to closed loop"/>
+                              <xs:enumeration value="Install food disposal load sensing device"/>
+                              <xs:enumeration value="Replace with ENERGY STAR-qualified commercial dishwashers"/>
+                              <xs:enumeration value="Replace with ENERGY STAR-qualified steam cookers or boilerless commercial steam cookers"/>
+                              <xs:enumeration value="Replace with ENERGY STAR-qualified ice machine"/>
+                              <xs:enumeration value="Replace food disposal with food pulper system"/>
+                              <xs:enumeration value="Install WaterSense-qualified pre-rinse spray valves"/>
+                              <xs:enumeration value="Install in-line flow restrictor on dipper wells"/>
+                              <xs:enumeration value="Install steam kettle with condensate return"/>
+                              <xs:enumeration value="Other"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="LaboratoryAndMedicalEquipments" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Improvements for laboratory and medical equipments.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="MeasureName" maxOccurs="unbounded">
+                          <xs:annotation>
+                            <xs:documentation>Short description of measure.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="Install dry vacuum or air-cooled vacuum pump"/>
+                              <xs:enumeration value="Retrofit liquid-ring vacuum pump with a water recovery system"/>
+                              <xs:enumeration value="Install digital photographic or X-ray equipment"/>
+                              <xs:enumeration value="Retrofit traditional photographic or X-ray equipment with a water recycling system"/>
+                              <xs:enumeration value="Install water-efficient glassware washer with water recycling system"/>
+                              <xs:enumeration value="Retrofit glassware washer with water recycling system"/>
+                              <xs:enumeration value="Install pretreatment of water purification equipment to increase system recovery"/>
+                              <xs:enumeration value="Install high efficiency water purification system with high recovery rate"/>
+                              <xs:enumeration value="Install steam sterilizer system with automated tempering system and automatic shut off"/>
+                              <xs:enumeration value="Retrofit vivarium washing equipment with water recycling system"/>
+                              <xs:enumeration value="Install water-efficient vivarium washing equipment with advanced controls and water recycling"/>
+                              <xs:enumeration value="Install water-efficient vivarium watering equipment with recirculation system"/>
+                              <xs:enumeration value="Install steam sterilizer condensate retrofit kit"/>
+                              <xs:enumeration value="Other"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="IrrigationSystemsAndLandscapingImprovements" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Improvements for irrigation systems and landscaping.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="MeasureName" maxOccurs="unbounded">
+                          <xs:annotation>
+                            <xs:documentation>Short description of measure.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="Install advanced weather-based irrigation controller"/>
+                              <xs:enumeration value="Install advanced soil-moisture based irrigation controller"/>
+                              <xs:enumeration value="Install water-efficient irrigation sprinkler heads"/>
+                              <xs:enumeration value="Reprogram irrigation controller to water-efficient settings"/>
+                              <xs:enumeration value="Install irrigation meter"/>
+                              <xs:enumeration value="Install micro-irrigation or drip irrigation"/>
+                              <xs:enumeration value="Install irrigation sprinkler shut-off device"/>
+                              <xs:enumeration value="Remove or Recirculate ornamental water feature"/>
+                              <xs:enumeration value="Install native/adaptive plants"/>
+                              <xs:enumeration value="Remove high water consuming plants or replace with native/adaptive plants"/>
+                              <xs:enumeration value="Other"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="WashingEquipmentsAndTechiques" minOccurs="0">
+                    <xs:annotation>
+                      <xs:documentation>Improvements for washing equipments and techiques.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="MeasureName" maxOccurs="unbounded">
+                          <xs:annotation>
+                            <xs:documentation>Short description of measure.</xs:documentation>
+                          </xs:annotation>
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="Install automatic shutoff nozzle for self-service vehicle wash"/>
+                              <xs:enumeration value="Implement water-efficient optimization for vehicle washing equipment"/>
+                              <xs:enumeration value="Retrofit vehicle washing equipment with water recycling system"/>
+                              <xs:enumeration value="Install high-pressure self-service vehicle washer"/>
+                              <xs:enumeration value="Install ozone system for laundry equipment"/>
+                              <xs:enumeration value="Install water-efficient conveyor/in-bay vehicle washing equipment"/>
+                              <xs:enumeration value="Install Energy STAR-qualified laundry washing machines"/>
+                              <xs:enumeration value="Install water-efficient industrial/commercial laundry equipment"/>
+                              <xs:enumeration value="Retrofit laundry washing equipment with water recycling system"/>
+                              <xs:enumeration value="Install meter on vehicle wash system"/>
+                              <xs:enumeration value="Other"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:element>
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
                   <xs:element name="FutureOtherECMs" minOccurs="0">
                     <xs:annotation>
                       <xs:documentation>Measures reserved for future and other ECMs.</xs:documentation>

--- a/proposals/2023/Add WCM Categories.md
+++ b/proposals/2023/Add WCM Categories.md
@@ -1,0 +1,112 @@
+# Add WCM Categories
+
+## Overview
+
+This proposal is to add new water conservation measure categories under `auc:Measure/auc:TechnologyCategories/auc:TechnologyCategory` and associated WCM measures.
+
+## Justification
+
+Based on discussion with FEMP on Water Conservation Measure from [WCM resources](https://www.energy.gov/femp/water-efficient-technology-opportunities) and PNNL measure development team on measure formatting, BuildingSync proposed to add several new measure categories related to WCMs, as well as associated measure names as enumerations. The new categories and associated measures are:
+### AlternativeWaterSources
+- Install condensate capture equipment
+- Install atmospheric water generator
+- Install wastewater treatment plant
+- Install rainwater harvesting system
+- Install cooling tower blowdown for appropriate applications
+- Install desalinated water treatment for reuse
+- Use discharged water from water purification processes
+- Install foundation water treatment for reuse
+- Install greywater reuse system
+### KitchenImprovements
+- Retrofit single-pass cooling ice machine to closed loop
+- Install food disposal load sensing device
+- Replace with ENERGY STAR-qualified commercial dishwashers
+- Replace with ENERGY STAR-qualified steam cookers or boilerless commercial steam cookers
+- Replace with ENERGY STAR-qualified ice machine
+- Replace food disposal with food pulper system
+- Install WaterSense-qualified pre-rinse spray valves 
+- Install in-line flow restrictor on dipper wells
+- Install steam kettle with condensate return
+### LaboratoryAndMedicalEquipments
+- Install dry vacuum air-cooled vacuum pump
+- Install digital photographic or X-ray equipment
+- Retrofit liquid-ring vacuum pump with a water recovery system
+- Install water-efficient glassware washer with water recycling system
+- Retrofit glassware washer with water recycling system
+- Retrofit traditional photographic or X-ray equipment with a water recycling system
+- Install pretreatment of water purification equipment to increase system recovery
+- Install high efficiency water purification system with high recovery rate
+- Install steam sterilizer system with automated tempering system and automatic shut off
+- Retrofit vivarium washing equipment with water recycling system
+- Install water-efficient vivarium washing equipment with advanced controls and water recycling
+- Install water-efficient vivarium watering equipment with recirculation system
+- Install steam sterilizer condensate retrofit kit
+### IrrigationSystemsAndLandscapingImprovements
+- Install advanced weather-based irrigation controller
+- Install advanced soil-moisture based irrigation controller
+- Install water-efficient irrigation sprinkler heads
+- Reprogram irrigation controller to water-efficient settings
+- Install irrigation meter
+- Install micro-irrigation or drip irrigation 
+- Install irrigation sprinkler shut-off device
+- Remove or Recirculate ornamental water feature
+- Install native/adaptive plants
+- Remove high water consuming plants or replace with native/adaptive plants
+### WashingEquipmentsAndTechiques
+- Install automatic shutoff nozzle for self-service vehicle wash
+- Implement water-efficient optimization for vehicle washing equipment
+- Retrofit vehicle washing equipment with water recycling system
+- Install high-pressure self-service vehicle washer
+- Install ozone system for laundry equipment
+- Install water-efficient conveyor/in-bay vehicle washing equipment
+- Install Energy STAR-qualified laundry washing machines
+- Install water-efficient industrial/commercial laundry equipment
+- Retrofit laundry washing equipment with water recycling system
+- Install meter on vehicle wash system
+In addition to the specific measures, all new categories will include an `Other` option to capture possible unclarified measures or measures not specified in the list.
+
+## Implementation
+The new categories and their enumerations will be added in the way identical to the existing measures in the hierarchy of `auc:Measure`
+    `auc:TechnologyCategories`
+        `auc:TechnologyCategory`
+            `auc:<CategoryName>`
+                `auc:MeasureName`
+                    `[enumerations]`.
+Thus in the updated schema, under `auc:TechnologyCategories`:
+```xml
+    <xs:element name="TechnologyCategory" maxOccurs="unbounded">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element name="AlternativeWaterSources" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="MeasureName" maxOccurs="unbounded">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Install condensate capture equipment"/>
+                                        ...
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="KitchenImprovements" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="MeasureName" maxOccurs="unbounded">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Retrofit single-pass cooling ice machine to closed loop"/>
+                                        ...
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                ...
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+```

--- a/proposals/2023/Add WCM Categories.md
+++ b/proposals/2023/Add WCM Categories.md
@@ -63,7 +63,7 @@ Based on discussion with FEMP on Water Conservation Measure from [WCM resources]
 - Install water-efficient industrial/commercial laundry equipment
 - Retrofit laundry washing equipment with water recycling system
 - Install meter on vehicle wash system
-In addition to the specific measures, all new categories will include an `Other` option to capture possible unclarified measures or measures not specified in the list.
+In addition to the specific measures, all new categories will include `Clean and/or repair`, `Implement training and/or documentation`, `Upgrade operating protocols, calibration, and/or sequencing` and `Other` options to capture general measures, possible unclarified measures or measures not specified in the list.
 
 ## Implementation
 The new categories and their enumerations will be added in the way identical to the existing measures in the hierarchy of `auc:Measure`

--- a/proposals/2023/Add WCM Categories.md
+++ b/proposals/2023/Add WCM Categories.md
@@ -28,12 +28,12 @@ Based on discussion with FEMP on Water Conservation Measure from [WCM resources]
 - Install in-line flow restrictor on dipper wells
 - Install steam kettle with condensate return
 ### LaboratoryAndMedicalEquipments
-- Install dry vacuum air-cooled vacuum pump
-- Install digital photographic or X-ray equipment
+- Install dry vacuum or air-cooled vacuum pump
 - Retrofit liquid-ring vacuum pump with a water recovery system
+- Install digital photographic or X-ray equipment
+- Retrofit traditional photographic or X-ray equipment with a water recycling system
 - Install water-efficient glassware washer with water recycling system
 - Retrofit glassware washer with water recycling system
-- Retrofit traditional photographic or X-ray equipment with a water recycling system
 - Install pretreatment of water purification equipment to increase system recovery
 - Install high efficiency water purification system with high recovery rate
 - Install steam sterilizer system with automated tempering system and automatic shut off

--- a/proposals/2023/Add WCM Categories.md
+++ b/proposals/2023/Add WCM Categories.md
@@ -59,7 +59,7 @@ Based on discussion with FEMP on Water Conservation Measure from [WCM resources]
 - Install high-pressure self-service vehicle washer
 - Install ozone system for laundry equipment
 - Install water-efficient conveyor/in-bay vehicle washing equipment
-- Install Energy STAR-qualified laundry washing machines
+- Install ENERGY STAR-qualified laundry washing machines
 - Install water-efficient industrial/commercial laundry equipment
 - Retrofit laundry washing equipment with water recycling system
 - Install meter on vehicle wash system


### PR DESCRIPTION
#### Any background context you want to provide?
BuildingSync is adding water conservation measures (WCMs) into its measure library. Based on iterations of discussion and edits on the list of WCM categories and measure names in [here](https://docs.google.com/spreadsheets/d/15GUAZ6koG7dWHk_P00Gi-j43kdJReL7C/edit?usp=sharing&ouid=117281173110888138505&rtpof=true&sd=true), several new categories are proposed with associated measures, and other measures are distributed to existing corresponding BuildingSync measure categories. 

#### What does this PR do?
This PR is to add the new categories and associated measures.

#### How should this be manually tested?

#### What are the relevant tickets?
[#165](https://github.com/BuildingSync/project-tracker/issues/165)

#### Screenshots (if appropriate)
