### PR TITLE
Add WCMs to existing categories

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3873,7 +3873,7 @@
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
                               <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
-                              <xs:enumeration value="Convert to Cleaner Fuels"/>                              
+                              <xs:enumeration value="Convert to Cleaner Fuels"/>
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3978,7 +3978,7 @@
                               <xs:enumeration value="Capture and return condensate"/>
                               <xs:enumeration value="Install or Upgrade Master Venting"/>
                               <xs:enumeration value="Retrofit single-pass cooling with an automatic shut-off device"/>
-                              <xs:enumeration value="Retrofit single-pass cooling to eliminate single pass with closed loop/recirculation system"/>
+                              <xs:enumeration value="Retrofit single-pass cooling with closed loop/recirculation system"/>
                               <xs:enumeration value="Install water-efficient evaporative cooler"/>
                               <xs:enumeration value="Replace water-cooled equipment with air-cooled equipment"/>
                               <xs:enumeration value="Clean and/or repair"/>

--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -3863,10 +3863,17 @@
                               <xs:enumeration value="Add energy recovery"/>
                               <xs:enumeration value="Convert gas-fired unit to boiler loop"/>
                               <xs:enumeration value="Convert system from steam to hot water"/>
+                              <xs:enumeration value="Add boiler automatic chemical feed system"/>
+                              <xs:enumeration value="Install boiler condensate return system"/>
+                              <xs:enumeration value="Install boiler automatic blowdown system"/>
+                              <xs:enumeration value="Install boiler blowdown heat exchanger"/>
+                              <xs:enumeration value="Install boiler expansion flash tank"/>
+                              <xs:enumeration value="Install meters on boiler make-up lines"/>
+                              <xs:enumeration value="Install dehumidification system"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
                               <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
-                              <xs:enumeration value="Convert to Cleaner Fuels"/>
+                              <xs:enumeration value="Convert to Cleaner Fuels"/>                              
                               <xs:enumeration value="Other"/>
                             </xs:restriction>
                           </xs:simpleType>
@@ -3892,6 +3899,13 @@
                               <xs:enumeration value="Install gas cooling"/>
                               <xs:enumeration value="Add or repair economizer cycle"/>
                               <xs:enumeration value="Add or replace cooling tower"/>
+                              <xs:enumeration value="Implement advanced cooling tower controls to manage cycles of concentration"/>
+                              <xs:enumeration value="Install cooling tower water treatment system"/>
+                              <xs:enumeration value="Install automated chemical feed systems for cooling tower management"/>
+                              <xs:enumeration value="Install conductivity controller for cooling tower management"/>
+                              <xs:enumeration value="Install covers on open distribution decks on top of cooling tower"/>
+                              <xs:enumeration value="Install flow meters on make-up and blowdown lines for cooling tower management"/>
+                              <xs:enumeration value="Install side-stream filtration system for cooling tower management"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
                               <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
@@ -3963,6 +3977,10 @@
                               <xs:enumeration value="Install variable refrigerant flow system"/>
                               <xs:enumeration value="Capture and return condensate"/>
                               <xs:enumeration value="Install or Upgrade Master Venting"/>
+                              <xs:enumeration value="Retrofit single-pass cooling with an automatic shut-off device"/>
+                              <xs:enumeration value="Retrofit single-pass cooling to eliminate single pass with closed loop/recirculation system"/>
+                              <xs:enumeration value="Install water-efficient evaporative cooler"/>
+                              <xs:enumeration value="Replace water-cooled equipment with air-cooled equipment"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
                               <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
@@ -4074,6 +4092,7 @@
                               <xs:enumeration value="Install or upgrade master venting"/>
                               <xs:enumeration value="Replace steam traps with orifice plates"/>
                               <xs:enumeration value="Install steam condensate heat recovery"/>
+                              <xs:enumeration value="Install leak detection system"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
                               <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>
@@ -4288,6 +4307,15 @@
                               <xs:enumeration value="Install low-flow plumbing equipment"/>
                               <xs:enumeration value="Install onsite sewer treatment systems"/>
                               <xs:enumeration value="Implement water efficient irrigation"/>
+                              <xs:enumeration value="Remove water softeners with timers"/>
+                              <xs:enumeration value="Install high-efficiency faucet aerator in lavatory public restrooms"/>
+                              <xs:enumeration value="Install WaterSense-qualified faucet aerator in lavatory private restrooms"/>
+                              <xs:enumeration value="Install WaterSense-qualified showerhead"/>
+                              <xs:enumeration value="Install WaterSense-qualified flushometer toilets"/>
+                              <xs:enumeration value="Install WaterSense-qualified tank toilets"/>
+                              <xs:enumeration value="Install WaterSense-qualified flushing urinal"/>
+                              <xs:enumeration value="Install leak detection system"/>
+                              <xs:enumeration value="Install temporary shut-off or foot-operated valves with kitchen faucets"/>
                               <xs:enumeration value="Clean and/or repair"/>
                               <xs:enumeration value="Implement training and/or documentation"/>
                               <xs:enumeration value="Upgrade operating protocols, calibration, and/or sequencing"/>

--- a/proposals/2023/Add WCMs to existing Measure Categories.md
+++ b/proposals/2023/Add WCMs to existing Measure Categories.md
@@ -1,0 +1,51 @@
+# Add WCM Categories
+
+## Overview
+
+This proposal is to add new water conservation measure enumerations for existing categories under `auc:Measure/auc:TechnologyCategories/auc:TechnologyCategory`.
+
+## Justification
+
+Based on discussion with FEMP on Water Conservation Measure from [WCM resources](https://www.energy.gov/femp/water-efficient-technology-opportunities) and PNNL measure development team on measure formatting, BuildingSync proposed to add various WCMs (and a few ECMs) to the existing measure categories. The categories and new measures are:
+### BoilerPlantImprovements
+- Add boiler automatic chemical feed system
+- Install boiler condensate return system
+- Install boiler automatic blowdown system
+- Install boiler blowdown heat exchanger (ECM)
+- Install boiler expansion flash tank (ECM)
+- Install meters on boiler make-up lines
+- Install dehumidification system (ECM)
+### ChilledWaterHotWaterAndSteamDistributionSystems
+- Install leak detection system
+### ChillerPlantImprovements
+- Implement advanced cooling tower controls to manage cycles of concentration
+- Install cooling tower water treatment system
+- Install automated chemical feed systems for cooling tower management
+- Install conductivity controller for cooling tower management
+- Install covers on open distribution decks on top of cooling tower 
+- Install flow meters on make-up and blowdown lines for cooling tower management
+- Install side-stream filtration system for cooling tower management
+### OtherHVAC
+- Retrofit single-pass cooling with an automatic shut-off device
+- Retrofit single-pass cooling to eliminate single pass with closed loop/recirculation system
+- Install water-efficient evaporative cooler 
+- Replace water-cooled equipment with air-cooled equipment
+### WaterAndSewerConservationSystems
+- Remove water softeners with timers
+- Install high-efficiency faucet aerator in lavatory public restrooms
+- Install WaterSense-qualified faucet aerator in lavatory private restrooms
+- Install WaterSense-qualified showerhead
+- Install WaterSense-qualified flushometer toilets
+- Install WaterSense-qualified tank toilets
+- Install WaterSense-qualified flushing urinal
+- Install leak detection system
+- Install temporary shut-off or foot-operated valves with kitchen faucets
+
+## Implementation
+The enumerations will be added in the way identical to the existing measures in the hierarchy of 
+`auc:Measure`
+    `auc:TechnologyCategories`
+        `auc:TechnologyCategory`
+            `auc:<CategoryName>`
+                `auc:MeasureName`
+                    `[enumerations]`.

--- a/proposals/2023/Add WCMs to existing Measure Categories.md
+++ b/proposals/2023/Add WCMs to existing Measure Categories.md
@@ -27,7 +27,7 @@ Based on discussion with FEMP on Water Conservation Measure from [WCM resources]
 - Install side-stream filtration system for cooling tower management
 ### OtherHVAC
 - Retrofit single-pass cooling with an automatic shut-off device
-- Retrofit single-pass cooling to eliminate single pass with closed loop/recirculation system
+- Retrofit single-pass cooling with closed loop/recirculation system
 - Install water-efficient evaporative cooler 
 - Replace water-cooled equipment with air-cooled equipment
 ### WaterAndSewerConservationSystems


### PR DESCRIPTION
#### Any background context you want to provide?
BuildingSync is adding water conservation measures (WCMs) into its measure library. Based on iterations of discussion and edits on the list of WCM categories and measure names in [here](https://docs.google.com/spreadsheets/d/15GUAZ6koG7dWHk_P00Gi-j43kdJReL7C/edit?usp=sharing&ouid=117281173110888138505&rtpof=true&sd=true), several new categories are proposed with associated measures, and other measures are distributed to existing corresponding BuildingSync measure categories. 

#### What does this PR do?
This PR is to add the new measures to existing BuildingSync measure categories.

#### How should this be manually tested?

#### What are the relevant tickets?
[#165](https://github.com/BuildingSync/project-tracker/issues/165)

#### Screenshots (if appropriate)
