### PR TITLE
fix typo in use of EquipmentCondition

### DIFF
--- a/BuildingSync.xsd
+++ b/BuildingSync.xsd
@@ -6327,7 +6327,7 @@
       <xs:element ref="auc:LinkedPremises" minOccurs="0"/>
       <xs:element ref="auc:LinkedFiles" minOccurs="0"/>
       <xs:element ref="auc:UserDefinedFields" minOccurs="0"/>
-      <xs:element name="DuctSystemCondition" name="auc:EquipmentCondition" minOccurs="0"/>
+      <xs:element name="DuctSystemCondition" type="auc:EquipmentCondition" minOccurs="0"/>
       <xs:element ref="auc:EquipmentID" minOccurs="0"/>
       <xs:element ref="auc:PrimaryFuel" minOccurs="0"/>
       <xs:element ref="auc:ThirdPartyCertification" minOccurs="0"/>


### PR DESCRIPTION
<!-- Before creating the PR make sure that the schema is formatted correctly.
  * Remove tabs (run bundle exec rake remove_tabs)
  * Ensure example files have been updated
-->

#### Any background context you want to provide?
The use of `EquipmentCondition` should be calling as a `<type>` of an element, while it's called as a `<name>` by mistake when used for defining element `HVACSystemCondition`. 

#### What does this PR do?
Fix the typo.

#### How should this be manually tested?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
